### PR TITLE
-fno-exceptions support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,11 @@ project(dsplib LANGUAGES CXX VERSION 0.25.0)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(DSPLIB_ASAN_ENABLED "Address sanitizer enabled" OFF)
 option(DSPLIB_USE_FLOAT32 "Use float32 for base type dsplib::real_t" OFF)
+option(DSPLIB_NO_EXCEPTIONS "Use the abort() function instead throw" OFF)
+
 option(DSPLIB_BUILD_TESTS "Build dsplib tests" OFF)
+option(DSPLIB_ASAN_ENABLED "Address sanitizer enabled" OFF)
 option(DSPLIB_BUILD_EXAMPLES "Build dsplib examples" OFF)
 
 file(GLOB_RECURSE DSPLIB_SOURCES 
@@ -31,6 +33,14 @@ if (DSPLIB_USE_FLOAT32)
     target_compile_definitions(${PROJECT_NAME} PUBLIC "DSPLIB_USE_FLOAT32")
 else()
     message(STATUS "dsplib: base type of real_t: float64")
+endif()
+
+if (DSPLIB_NO_EXCEPTIONS)
+    message(STATUS "dsplib: disable exceptions")
+    target_compile_options(${PROJECT_NAME} PRIVATE -fno-exceptions)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "DSPLIB_NO_EXCEPTIONS")
+else()
+    message(STATUS "dsplib: enable exceptions")
 endif()
 
 # check warnings

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -7,6 +7,7 @@
 #include <dsplib/types.h>
 #include <dsplib/slice.h>
 #include <dsplib/indexing.h>
+#include <dsplib/throw.h>
 
 namespace dsplib {
 
@@ -292,7 +293,7 @@ public:
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator+=(const base_array<T2>& rhs) {
         if (this->size() != rhs.size()) {
-            throw std::invalid_argument("array sizes are different");
+            DSPLIB_THROW("array sizes are different");
         }
 
         for (size_t i = 0; i < _vec.size(); ++i) {
@@ -305,7 +306,7 @@ public:
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator-=(const base_array<T2>& rhs) {
         if (this->size() != rhs.size()) {
-            throw std::invalid_argument("array sizes are different");
+            DSPLIB_THROW("array sizes are different");
         }
 
         for (size_t i = 0; i < _vec.size(); ++i) {
@@ -318,7 +319,7 @@ public:
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator*=(const base_array<T2>& rhs) {
         if (this->size() != rhs.size()) {
-            throw std::invalid_argument("array sizes are different");
+            DSPLIB_THROW("array sizes are different");
         }
 
         for (size_t i = 0; i < _vec.size(); ++i) {
@@ -331,7 +332,7 @@ public:
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator/=(const base_array<T2>& rhs) {
         if (this->size() != rhs.size()) {
-            throw std::invalid_argument("array sizes are different");
+            DSPLIB_THROW("array sizes are different");
         }
 
         for (size_t i = 0; i < _vec.size(); ++i) {
@@ -389,7 +390,7 @@ public:
     //TODO: implement pow(cmplx_t, cmplx_t)
     base_array<T>& operator^=(const base_array<real_t>& rhs) {
         if (rhs.size() != _vec.size()) {
-            throw std::invalid_argument("different vector size");
+            DSPLIB_THROW("different vector size");
         }
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] = std::pow(_vec[i], rhs[i]);

--- a/include/dsplib/lms.h
+++ b/include/dsplib/lms.h
@@ -40,7 +40,7 @@ public:
 
     result_t process(const base_array<T>& x, const base_array<T>& d) {
         if (x.size() != d.size()) {
-            throw std::runtime_error("vector size error: len(x) != len(d)");
+            DSPLIB_THROW("vector size error: len(x) != len(d)");
         }
 
         int nx = x.size();

--- a/include/dsplib/rls.h
+++ b/include/dsplib/rls.h
@@ -66,7 +66,7 @@ using crls = base_rls<cmplx_t>;
 template<typename T>
 typename base_rls<T>::result_t base_rls<T>::process(const base_array<T>& x, const base_array<T>& d) {
     if (x.size() != d.size()) {
-        throw std::runtime_error("vector size error: len(x) != len(d)");
+        DSPLIB_THROW("vector size error: len(x) != len(d)");
     }
 
     const int nx = x.size();

--- a/include/dsplib/slice.h
+++ b/include/dsplib/slice.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <cstring>
-#include <stdexcept>
+
+#include <dsplib/throw.h>
 
 namespace dsplib {
 
@@ -21,11 +22,11 @@ class base_slice_t
 public:
     explicit base_slice_t(int n, int i1, int i2, int m) {
         if (n == 0) {
-            throw std::range_error("Slicing from an empty array");
+            DSPLIB_THROW("Slicing from an empty array");
         }
 
         if (m == 0) {
-            throw std::range_error("Slice stride cannot be zero");
+            DSPLIB_THROW("Slice stride cannot be zero");
         }
 
         _m = m;
@@ -35,23 +36,23 @@ public:
         _nc = std::abs((_i2 - _i1) / _m);
 
         if ((_i1 < 0) || (_i1 >= _n)) {
-            throw std::out_of_range("Left slice index out of range");
+            DSPLIB_THROW("Left slice index out of range");
         }
 
         if ((_i2 < 0) || (_i2 > _n)) {
-            throw std::out_of_range("Right slice index out of range");
+            DSPLIB_THROW("Right slice index out of range");
         }
 
         if ((_m < 0) && (_i1 < _i2)) {
-            throw std::range_error("First index is smaller for negative step");
+            DSPLIB_THROW("First index is smaller for negative step");
         }
 
         if ((_m > 0) && (_i1 > _i2)) {
-            throw std::range_error("First index is greater for positive step");
+            DSPLIB_THROW("First index is greater for positive step");
         }
 
         if (_nc > _n) {
-            throw std::range_error("Slice range is greater vector size");
+            DSPLIB_THROW("Slice range is greater vector size");
         }
     }
 
@@ -125,7 +126,7 @@ public:
 
         const int count = dst_count;
         if (dst_count != src_count) {
-            throw std::out_of_range("Not equal size");
+            DSPLIB_THROW("Not equal size");
         }
 
         if (count == 0) {
@@ -164,7 +165,7 @@ public:
 
     slice_t& operator=(const base_array<T>& rhs) {
         if (&_base == &rhs) {
-            throw std::runtime_error("Assigned array to same slice");
+            DSPLIB_THROW("Assigned array to same slice");
         }
         return (*this = rhs.slice(0, rhs.size()));
     }

--- a/include/dsplib/throw.h
+++ b/include/dsplib/throw.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifdef DSPLIB_NO_EXCEPTIONS
+
+#include <iostream>
+
+//TODO: add filename to message
+#define DSPLIB_THROW(MSG)                                                                                              \
+    std::cerr << (std::string("dsplib: ") + MSG) << std::endl;                                                         \
+    std::abort();
+
+#else
+
+#include <stdexcept>
+
+#define DSPLIB_THROW(MSG) throw std::runtime_error(std::string("dsplib: ") + MSG);
+
+#endif

--- a/include/dsplib/utils.h
+++ b/include/dsplib/utils.h
@@ -98,7 +98,7 @@ inline std::vector<T> from_real(const arr_real& arr) {
 template<typename T>
 inline arr_cmplx to_complex(const T* x, size_t nx) {
     if (nx % 2 != 0) {
-        throw(std::runtime_error("Array size is not even"));
+        DSPLIB_THROW("Array size is not even");
     }
 
     const T* p = x;
@@ -131,7 +131,7 @@ inline std::vector<T> from_complex(const arr_cmplx& arr) {
 template<typename T>
 inline base_array<T> zeropad(const base_array<T>& x, int n) {
     if (x.size() > n) {
-        throw std::runtime_error("padding size error");
+        DSPLIB_THROW("padding size error");
     }
 
     if (x.size() == n) {

--- a/lib/agc.cpp
+++ b/lib/agc.cpp
@@ -66,7 +66,7 @@ agc::agc(double target_level, double max_gain, int average_len, double t_rise, d
     _d = std::unique_ptr<agc_impl>(new agc_impl());
 
     if (average_len == 0) {
-        throw std::runtime_error("average_len must be greater 0");
+        DSPLIB_THROW("average_len must be greater 0");
     }
 
     _d->rms_period = average_len;

--- a/lib/datacache.h
+++ b/lib/datacache.h
@@ -3,6 +3,8 @@
 #include <mutex>
 #include <map>
 
+#include <dsplib/throw.h>
+
 namespace dsplib {
 
 template<typename K, typename T>
@@ -11,29 +13,25 @@ class datacache
 public:
     datacache() = default;
 
-    void update(K key, const T& value)
-    {
+    void update(K key, const T& value) {
         std::lock_guard<std::mutex> lk(_mtx);
         _cache[key] = value;
     }
 
-    T get(K key) const
-    {
+    T get(K key) const {
         std::lock_guard<std::mutex> lk(_mtx);
         if (_cache.count(key) == 0) {
-            throw std::runtime_error("error getting value. the data has not been cached.");
+            DSPLIB_THROW("error getting value. the data has not been cached.");
         }
         return _cache.at(key);
     }
 
-    bool cached(K key) const
-    {
+    bool cached(K key) const {
         std::lock_guard<std::mutex> lk(_mtx);
         return _cache.count(key) != 0;
     }
 
-    void reset(K key)
-    {
+    void reset(K key) {
         std::lock_guard<std::mutex> lk(_mtx);
         if (_cache.count(key) == 0) {
             return;

--- a/lib/math.cpp
+++ b/lib/math.cpp
@@ -1,6 +1,5 @@
 #include <dsplib/math.h>
 
-#include <stdexcept>
 #include <algorithm>
 #include <cmath>
 
@@ -152,7 +151,7 @@ cmplx_t sum(const arr_cmplx& arr) {
 //-------------------------------------------------------------------------------------------------
 real_t dot(const arr_real& x1, const arr_real& x2) {
     if (x1.size() != x2.size()) {
-        throw std::runtime_error("array sizes are different");
+        DSPLIB_THROW("array sizes are different");
     }
     real_t acc = 0;
     for (int i = 0; i < x1.size(); ++i) {
@@ -163,7 +162,7 @@ real_t dot(const arr_real& x1, const arr_real& x2) {
 
 cmplx_t dot(const arr_cmplx& x1, const arr_cmplx& x2) {
     if (x1.size() != x2.size()) {
-        throw std::runtime_error("array sizes are different");
+        DSPLIB_THROW("array sizes are different");
     }
     cmplx_t acc = 0;
     for (int i = 0; i < x1.size(); ++i) {
@@ -255,7 +254,7 @@ int nextpow2(int m) {
 //-------------------------------------------------------------------------------------------------
 arr_cmplx complex(const arr_real& re, const arr_real& im) {
     if (re.size() != im.size()) {
-        throw std::invalid_argument("array sizes are different");
+        DSPLIB_THROW("array sizes are different");
     }
 
     int n = re.size();
@@ -470,11 +469,11 @@ cmplx_t expj(real_t im) {
 template<class T>
 static T _downsample(const T& arr, int n, int phase) {
     if (n <= 0) {
-        throw std::invalid_argument("downsample factor must be greater 0");
+        DSPLIB_THROW("downsample factor must be greater 0");
     }
 
     if (phase >= n || phase < 0) {
-        throw std::invalid_argument("phase must be [0, N-1]");
+        DSPLIB_THROW("phase must be [0, N-1]");
     }
 
     if (n == 1) {
@@ -503,11 +502,11 @@ arr_cmplx downsample(const arr_cmplx& arr, int n, int phase) {
 template<class T>
 static T _upsample(const T& arr, int n, int phase) {
     if (n <= 0) {
-        throw std::invalid_argument("upsample factor must be greater 0");
+        DSPLIB_THROW("upsample factor must be greater 0");
     }
 
     if (phase >= n || phase < 0) {
-        throw std::invalid_argument("phase must be [0, N-1]");
+        DSPLIB_THROW("phase must be [0, N-1]");
     }
 
     if (n == 1) {

--- a/lib/sinad.cpp
+++ b/lib/sinad.cpp
@@ -9,7 +9,7 @@ namespace dsplib {
 //------------------------------------------------------------------------------------
 real_t sinad(const arr_real& x) {
     if (x.size() > 0x7fff) {
-        throw std::runtime_error("The vector size is too large");
+        DSPLIB_THROW("The vector size is too large");
     }
 
     const int n = 1L << nextpow2(x.size());

--- a/lib/tuner.cpp
+++ b/lib/tuner.cpp
@@ -9,8 +9,7 @@ namespace dsplib {
 
 //-------------------------------------------------------------------------------------------------
 //TODO: combine tables for multiples freq / fs (example 100/8000 == 5/400)
-tuner::sin_table_t tuner::get_table(int fs)
-{
+tuner::sin_table_t tuner::get_table(int fs) {
     static std::map<int, sin_table_t> fs_table;
     static std::mutex mutex;
 
@@ -29,10 +28,9 @@ tuner::sin_table_t tuner::get_table(int fs)
 }
 
 //-------------------------------------------------------------------------------------------------
-tuner::tuner(int fs, int freq)
-{
+tuner::tuner(int fs, int freq) {
     if (abs(freq) > fs / 2) {
-        throw std::runtime_error("freq is greater than half of sample rate");
+        DSPLIB_THROW("freq is greater than half of sample rate");
     }
     _fs = fs;
     _freq = freq;
@@ -41,8 +39,7 @@ tuner::tuner(int fs, int freq)
 }
 
 //-------------------------------------------------------------------------------------------------
-arr_cmplx tuner::process(const arr_cmplx& x)
-{
+arr_cmplx tuner::process(const arr_cmplx& x) {
     if (_freq == 0) {
         return x;
     }
@@ -76,18 +73,16 @@ arr_cmplx tuner::process(const arr_cmplx& x)
 }
 
 //-------------------------------------------------------------------------------------------------
-void tuner::set_freq(int freq)
-{
+void tuner::set_freq(int freq) {
     if (abs(freq) > _fs / 2) {
-        throw std::runtime_error("freq is greater than half of sample rate");
+        DSPLIB_THROW("freq is greater than half of sample rate");
     }
 
     _freq = freq;
 }
 
 //-------------------------------------------------------------------------------------------------
-int tuner::freq() const
-{
+int tuner::freq() const {
     return _freq;
 }
 

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -133,7 +133,7 @@ template<typename T>
 arr_real _from_file(std::string file, size_t count, endian order, size_t offset) {
     FILE* fid = fopen(file.c_str(), "rb");
     if (!fid) {
-        throw std::runtime_error("open file error");
+        DSPLIB_THROW("open file error");
     }
 
     uint8_t bytes[sizeof(T)];


### PR DESCRIPTION
Build without using exceptions. The abort function is used instead of throw. 
Relevant for embedded systems.