### PR TITLE
Added span implementation

### DIFF
--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -6,6 +6,7 @@
 
 #include <dsplib/types.h>
 #include <dsplib/slice.h>
+#include <dsplib/span.h>
 #include <dsplib/indexing.h>
 #include <dsplib/throw.h>
 
@@ -138,20 +139,37 @@ public:
     }
 
     //--------------------------------------------------------------------
-    slice_t<T> slice(int i1, int i2, int m = 1) {
+    slice_t<T> slice(int i1, int i2, int m) {
         return slice_t<T>(*this, i1, i2, m);
     }
 
-    const_slice_t<T> slice(int i1, int i2, int m = 1) const {
-        return const_slice_t<T>(*this, i1, i2, m);
-    }
-
-    slice_t<T> slice(int i1, indexing::end_t, int m = 1) {
+    slice_t<T> slice(int i1, indexing::end_t, int m) {
         return slice_t<T>(*this, i1, size(), m);
     }
 
-    const_slice_t<T> slice(int i1, indexing::end_t, int m = 1) const {
+    const_slice_t<T> slice(int i1, int i2, int m) const {
+        return const_slice_t<T>(*this, i1, i2, m);
+    }
+
+    const_slice_t<T> slice(int i1, indexing::end_t, int m) const {
         return const_slice_t<T>(*this, i1, size(), m);
+    }
+
+    //use span for stride=1
+    span_t<T> slice(int i1, int i2) {
+        return span_t<T>(*this, i1, i2);
+    }
+
+    span_t<T> slice(int i1, indexing::end_t) {
+        return span_t<T>(*this, i1, size());
+    }
+
+    const_span_t<T> slice(int i1, int i2) const {
+        return const_span_t<T>(*this, i1, i2);
+    }
+
+    const_span_t<T> slice(int i1, indexing::end_t) const {
+        return const_span_t<T>(*this, i1, size());
     }
 
     //--------------------------------------------------------------------

--- a/include/dsplib/math.h
+++ b/include/dsplib/math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <dsplib/array.h>
+#include <dsplib/span.h>
 
 #include <limits>
 

--- a/include/dsplib/slice.h
+++ b/include/dsplib/slice.h
@@ -88,11 +88,11 @@ public:
       , _base{rhs._base} {
     }
 
-    int size() const {
+    int size() const noexcept {
         return _nc;
     }
 
-private:
+protected:
     const base_array<T>& _base;
 };
 
@@ -113,7 +113,7 @@ public:
       , _base{rhs._base} {
     }
 
-    int size() const {
+    int size() const noexcept {
         return _nc;
     }
 
@@ -142,6 +142,7 @@ public:
         const bool is_dirrect = (dst_t0 < dst_t1) && (src_t0 < src_t1);
 
         //simple block copy/move
+        //TODO: move to span implementation
         if ((dst_step == src_step) && (dst_step == 1) && is_dirrect) {
             if (!is_same_vec) {
                 std::memcpy((dst_p + dst_t0), (src_p + src_t0), count * sizeof(T));
@@ -189,7 +190,7 @@ public:
         return (*this = base_array<T>(list));
     }
 
-private:
+protected:
     static void _assign(const T* restrict src, T* restrict dst, int src_step, int dst_step, int src_init, int dst_init,
                         int count) {
         int idx_dst = dst_init;

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <dsplib/slice.h>
+
+namespace dsplib {
+
+template<class T>
+class const_span_t;
+
+template<class T>
+class span_t;
+
+//span is a slice with a stride of 1
+//used to quickly access vector elements in functions (without memory allocation)
+
+//mutable span
+template<typename T>
+class span_t : public slice_t<T>
+{
+public:
+    friend class const_span_t<T>;
+
+    explicit span_t(base_array<T>& v, int i1, int i2)
+      : slice_t<T>(v, i1, i2, 1)
+      , _ptr{v.data() + i1}
+      , _len{slice_t<T>::size()} {
+    }
+
+    span_t(base_array<T>& v)
+      : span_t(v, 0, v.size()) {
+    }
+
+    T* data() noexcept {
+        return _ptr;
+    }
+
+    int size() const noexcept {
+        return _len;
+    }
+
+    T& operator()(int i) noexcept {
+        assert((i >= 0) && (i < _len));
+        return _ptr[i];
+    }
+
+    T& operator[](int i) noexcept {
+        assert((i >= 0) && (i < _len));
+        return _ptr[i];
+    }
+
+    //TODO: override fast implementation for span
+
+    span_t& operator=(const const_slice_t<T>& rhs) {
+        slice_t<T>::operator=(rhs);
+        return *this;
+    }
+
+    span_t& operator=(const slice_t<T>& rhs) {
+        slice_t<T>::operator=(rhs);
+        return *this;
+    }
+
+    span_t& operator=(const base_array<T>& rhs) {
+        slice_t<T>::operator=(rhs);
+        return *this;
+    }
+
+    span_t& operator=(const T& rhs) {
+        std::fill(_ptr, (_ptr + _len), rhs);
+        return *this;
+    }
+
+    span_t& operator=(const std::initializer_list<T>& rhs) {
+        slice_t<T>::operator=(rhs);
+        return *this;
+    }
+
+private:
+    T* _ptr{nullptr};
+    int _len{0};
+};
+
+//immutable span
+template<typename T>
+class const_span_t : public const_slice_t<T>
+{
+public:
+    friend class span_t<T>;
+
+    explicit const_span_t(const base_array<T>& v, int i1, int i2)
+      : const_slice_t<T>(v, i1, i2, 1)
+      , _ptr{v.data() + i1}
+      , _len{const_slice_t<T>::size()} {
+    }
+
+    const_span_t(const span_t<T>& v)
+      : const_span_t(v._base, v._i1, v._i2) {
+    }
+
+    const_span_t(const base_array<T>& v)
+      : const_span_t(v, 0, v.size()) {
+    }
+
+    const T* data() const noexcept {
+        return _ptr;
+    }
+
+    int size() const noexcept {
+        return _len;
+    }
+
+    const T& operator()(int i) const noexcept {
+        assert((i >= 0) && (i < _len));
+        return _ptr[i];
+    }
+
+    const T& operator[](int i) const noexcept {
+        assert((i >= 0) && (i < _len));
+        return _ptr[i];
+    }
+
+private:
+    const T* _ptr{nullptr};
+    int _len{0};
+};
+
+using const_span_real = const_span_t<real_t>;
+using const_span_cmplx = const_span_t<cmplx_t>;
+
+}   // namespace dsplib

--- a/tests/span_test.cpp
+++ b/tests/span_test.cpp
@@ -1,0 +1,36 @@
+#include "tests_common.h"
+#include <gtest/gtest.h>
+
+using namespace dsplib;
+
+static real_t _first_span_elem(const const_span_real& x) {
+    return x[0];
+}
+
+//-------------------------------------------------------------------------------------------------
+TEST(SpanTest, Base) {
+    {
+        arr_real x1 = {-1, 1, 2, 3};
+        auto span = x1.slice(0, indexing::end);
+        ASSERT_EQ(span.size(), 4);
+        arr_real x2(span);
+        ASSERT_EQ_ARR_REAL(x1, x2);
+        ASSERT_EQ(_first_span_elem(span), -1);
+        ASSERT_EQ(_first_span_elem(x1), -1);
+    }
+
+    {
+        arr_real x1 = {-1, 2, -3, 4, -5};
+        auto span = x1.slice(1, 3);
+        ASSERT_EQ(span.size(), 2);
+        arr_real x2(span);
+        ASSERT_EQ_ARR_REAL(x2, arr_real{2, -3});
+        ASSERT_EQ(_first_span_elem(span), 2);
+    }
+
+    {
+        arr_real x1 = {-1, 2, -3, 4, -5};
+        x1.slice(0, 2) = 100;
+        ASSERT_EQ_ARR_REAL(x1, arr_real{100, 100, -3, 4, -5});
+    }
+}


### PR DESCRIPTION
The span class is implemented as a subclass of slice for backwards compatibility. 
The return type is determined by the type of the base_array::slice function (for a default stride of 1).