### PR TITLE
Span API support

### DIFF
--- a/.github/workflows/android-ndk.yml
+++ b/.github/workflows/android-ndk.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore: ["README.md"]
 
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore: ["README.md"]
 
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 env:
   BUILD_TYPE: Debug

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore: ["README.md"]
 
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 env:
   BUILD_TYPE: Release

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,68 @@
+{
+    "version": 8,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 18,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "DSPLIB_BUILD_TESTS": "OFF",
+                "DSPLIB_BUILD_BENCHS": "OFF",
+                "DSPLIB_BUILD_EXAMPLES": "OFF",
+                "DSPLIB_USE_FLOAT32": "OFF",
+                "DSPLIB_EXCLUDE_FFT": "OFF",
+                "DSPLIB_ASAN_ENABLED": "OFF",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/install"
+            },
+            "environment": {
+                "CC": "clang",
+                "CXX": "clang++"
+            },
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            }
+        },
+        {
+            "name": "tests",
+            "inherits": "default",
+            "cacheVariables": {
+                "DSPLIB_BUILD_TESTS": "ON",
+                "DSPLIB_ASAN_ENABLED": "ON"
+            }
+        },
+        {
+            "name": "benchs-float64",
+            "inherits": "default",
+            "cacheVariables": {
+                "DSPLIB_BUILD_BENCHS": "ON",
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "benchs-float32",
+            "inherits": "default",
+            "cacheVariables": {
+                "DSPLIB_BUILD_BENCHS": "ON",
+                "CMAKE_BUILD_TYPE": "Release",
+                "DSPLIB_USE_FLOAT32": "ON"
+            }
+        },
+        {
+            "name": "examples",
+            "inherits": "default",
+            "cacheVariables": {
+                "DSPLIB_BUILD_EXAMPLES": "ON",
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}

--- a/benchs/adaptive.cpp
+++ b/benchs/adaptive.cpp
@@ -3,7 +3,7 @@
 
 static std::pair<dsplib::arr_real, dsplib::arr_real> _prepare_frame(int M, int L) {
     const auto h = dsplib::randn(M);
-    auto flt = dsplib::FftFilter(h);
+    auto flt = dsplib::FirFilter(h);
     auto x = dsplib::randn(L);
     auto n = 0.01 * dsplib::randn(L);
     auto d = flt(x) + n;

--- a/benchs/fft.cpp
+++ b/benchs/fft.cpp
@@ -92,13 +92,12 @@ BENCHMARK(BM_FFTW3_DOUBLE)
 #endif
 
 static void BM_FFT_DSPLIB(benchmark::State& state) {
-    using namespace dsplib;
     const int n = state.range(0);
     auto x = complex(dsplib::randn(n));
     dsplib::arr_cmplx y = dsplib::fft(x);   ///< update cache
     for (auto _ : state) {
         x[0] += 1e-5;
-        y = fft(x);
+        y = dsplib::fft(x);
     }
 }
 

--- a/benchs/fft.cpp
+++ b/benchs/fft.cpp
@@ -92,12 +92,13 @@ BENCHMARK(BM_FFTW3_DOUBLE)
 #endif
 
 static void BM_FFT_DSPLIB(benchmark::State& state) {
+    using namespace dsplib;
     const int n = state.range(0);
     auto x = complex(dsplib::randn(n));
     dsplib::arr_cmplx y = dsplib::fft(x);   ///< update cache
     for (auto _ : state) {
         x[0] += 1e-5;
-        y = dsplib::fft(x);
+        y = fft(x);
     }
 }
 

--- a/examples/fftw-backend/fft.cpp
+++ b/examples/fftw-backend/fft.cpp
@@ -28,7 +28,7 @@ public:
         fftw_free(in_);
     }
 
-    dsplib::arr_cmplx solve(const dsplib::arr_cmplx& x) const final {
+    dsplib::arr_cmplx solve(span_t<cmplx_t> x) const final {
         DSPLIB_ASSERT(x.size() == n_, "input size must be equal `n`");
         std::memcpy(in_, x.data(), n_ * sizeof(x[0]));
         fftw_execute(plan_);
@@ -66,7 +66,7 @@ public:
         fftw_free(in_);
     }
 
-    dsplib::arr_cmplx solve(const dsplib::arr_real& x) const final {
+    dsplib::arr_cmplx solve(span_t<real_t> x) const final {
         DSPLIB_ASSERT(x.size() == n_, "input size must be equal `n`");
         std::memcpy(in_, x.data(), n_ * sizeof(x[0]));
         fftw_execute(plan_);
@@ -105,7 +105,7 @@ public:
         fftw_free(in_);
     }
 
-    dsplib::arr_real solve(const dsplib::arr_cmplx& x) const final {
+    dsplib::arr_real solve(span_t<cmplx_t> x) const final {
         const int n2 = n_ / 2 + 1;
         DSPLIB_ASSERT((x.size() == n_) || (x.size() == n2), "input size must be equal `n` or `n/2+1`");
         std::memcpy(in_, x.data(), n2 * sizeof(x[0]));

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -72,37 +72,6 @@ constexpr bool is_array_convertible() noexcept {
     return true;
 }
 
-//rules for implicit array conversion
-//TODO: use static_assert and verbose error message
-template<typename T_src, typename T_dst>
-constexpr bool is_array_castable() noexcept {
-    if constexpr (!std::is_convertible_v<T_src, T_dst>) {
-        return false;
-    }
-
-    //only arithmetic scalar
-    if constexpr (!is_scalar_v<T_src> || !is_scalar_v<T_dst>) {
-        return false;
-    }
-
-    //cmplx -> real
-    if constexpr (is_complex_v<T_src> && !is_complex_v<T_dst>) {
-        return false;
-    }
-
-    //real -> cmplx
-    if constexpr (!is_complex_v<T_src> && is_complex_v<T_dst>) {
-        return false;
-    }
-
-    //float -> int
-    if constexpr (std::is_floating_point_v<T_src> && std::is_integral_v<T_dst>) {
-        return false;
-    }
-
-    return true;
-}
-
 //base dsplib array type
 //TODO: add array_view as parent for array/slice
 //TODO: add slice(vector<bool>)
@@ -163,7 +132,7 @@ public:
 
     template<typename T2>
     explicit base_array(span_t<T2> v) {
-        static_assert(is_array_castable<T2, T>(), "Only real2real/cmplx2cmplx array cast support");
+        static_assert(is_array_convertible<T2, T>(), "Only real2real/cmplx2cmplx array cast support");
         _vec.assign(v.begin(), v.end());
     }
 

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -9,6 +9,7 @@
 #include <dsplib/slice.h>
 #include <dsplib/indexing.h>
 #include <dsplib/assert.h>
+#include <dsplib/span.h>
 
 namespace dsplib {
 
@@ -25,8 +26,8 @@ using ResultType = conditional_t<std::is_same_v<T1, cmplx_t> || std::is_same_v<T
 
 template<typename T_dst, typename T_src>
 base_array<T_dst> array_cast(const base_array<T_src>& src) noexcept {
-    static_assert(is_scalar_v<T_src> && is_scalar_v<T_dst>, "types must be scalar");
-    static_assert(!(is_complex_v<T_src> && !is_complex_v<T_dst>), "complex to real cast is not allowed");
+    static_assert(is_scalar_v<T_src> && is_scalar_v<T_dst>, "Types must be scalar");
+    static_assert(!(is_complex_v<T_src> && !is_complex_v<T_dst>), "Complex to real cast is not allowed");
     if constexpr (std::is_same_v<T_src, T_dst>) {
         return src;
     } else if constexpr (!is_complex_v<T_src> && is_complex_v<T_dst>) {
@@ -69,24 +70,6 @@ constexpr bool is_array_convertible() noexcept {
     }
 
     return true;
-}
-
-template<typename T_dst, typename T_src>
-base_array<T_dst> array_cast(const base_array<T_src>& src) noexcept {
-    static_assert(is_scalar_v<T_src> && is_scalar_v<T_dst>, "Types must be scalar");
-    static_assert(!(is_complex_v<T_src> && !is_complex_v<T_dst>), "Complex to Real cast is not allowed");
-
-    if constexpr (std::is_same_v<T_src, T_dst>) {
-        return src;
-    } else if constexpr (!is_complex_v<T_src> && is_complex_v<T_dst>) {
-        base_array<T_dst> dst(src.size());
-        for (int i = 0; i < src.size(); ++i) {
-            dst[i].re = static_cast<real_t>(src[i]);
-        }
-        return dst;
-    } else {
-        return base_array<T_dst>(src);
-    }
 }
 
 //rules for implicit array conversion
@@ -320,16 +303,6 @@ public:
         auto r = (*this == rhs);
         r.flip();
         return r;
-    }
-
-    //--------------------------------------------------------------------
-    //TODO: remove
-    const T& operator()(int i) const noexcept {
-        return this->operator[](i);
-    }
-
-    T& operator()(int i) noexcept {
-        return this->operator[](i);
     }
 
     //--------------------------------------------------------------------

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -120,7 +120,7 @@ public:
 
     template<typename T2>
     base_array(const std::vector<T2>& v)
-      : base_array(span(v)) {
+      : base_array(make_span(v)) {
     }
 
     base_array(std::vector<T>&& v)

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -72,9 +72,12 @@ constexpr bool is_array_convertible() noexcept {
     return true;
 }
 
-//base dsplib array type
-//TODO: add array_view as parent for array/slice
-//TODO: add slice(vector<bool>)
+/**
+ * @brief base dsplib array type
+ * @todo add array_view as parent for array/slice
+ * @todo add slice(vector<bool>)
+ * @tparam T real_t/cmplx_t/int
+ */
 template<typename T>
 class base_array
 {
@@ -85,13 +88,13 @@ public:
       : _vec(n, 0) {
     }
 
-    base_array(const const_slice_t<T>& rhs)
+    base_array(const slice_t<T>& rhs)
       : base_array(rhs.size()) {
         this->slice(0, indexing::end) = rhs;
     }
 
-    base_array(const slice_t<T>& rhs)
-      : base_array(const_slice_t<T>(rhs)) {
+    base_array(const mut_slice_t<T>& rhs)
+      : base_array(slice_t<T>(rhs)) {
     }
 
     base_array(const std::vector<T>& v)
@@ -131,13 +134,13 @@ public:
     }
 
     template<typename T2>
-    explicit base_array(span_t<T2> v) {
+    explicit base_array(const span_t<T2>& v) {
         static_assert(is_array_convertible<T2, T>(), "Only real2real/cmplx2cmplx array cast support");
         _vec.assign(v.begin(), v.end());
     }
 
     template<typename T2>
-    explicit base_array(mut_span_t<T2> v)
+    explicit base_array(const mut_span_t<T2>& v)
       : base_array(span_t<T2>(v)) {
     }
 
@@ -275,20 +278,20 @@ public:
     }
 
     //--------------------------------------------------------------------
-    slice_t<T> slice(int i1, int i2, int m) {
+    mut_slice_t<T> slice(int i1, int i2, int m) {
+        return mut_slice_t<T>(_vec.data(), _vec.size(), i1, i2, m);
+    }
+
+    slice_t<T> slice(int i1, int i2, int m) const {
         return slice_t<T>(_vec.data(), _vec.size(), i1, i2, m);
     }
 
-    const_slice_t<T> slice(int i1, int i2, int m) const {
-        return const_slice_t<T>(_vec.data(), _vec.size(), i1, i2, m);
-    }
-
     //TODO: add slice(end, first, -1) like x[::-1] numpy
-    slice_t<T> slice(int i1, indexing::end_t, int m) {
+    mut_slice_t<T> slice(int i1, indexing::end_t, int m) {
         return this->slice(i1, size(), m);
     }
 
-    const_slice_t<T> slice(int i1, indexing::end_t, int m) const {
+    slice_t<T> slice(int i1, indexing::end_t, int m) const {
         return this->slice(i1, size(), m);
     }
 

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -291,11 +291,11 @@ public:
 
     //--------------------------------------------------------------------
     mut_slice_t<T> slice(int i1, int i2, int m) {
-        return mut_slice_t<T>(_vec.data(), _vec.size(), i1, i2, m);
+        return mut_slice_t<T>::make_slice(_vec.data(), _vec.size(), i1, i2, m);
     }
 
     slice_t<T> slice(int i1, int i2, int m) const {
-        return slice_t<T>(_vec.data(), _vec.size(), i1, i2, m);
+        return slice_t<T>::make_slice(_vec.data(), _vec.size(), i1, i2, m);
     }
 
     //TODO: add slice(end, first, -1) like x[::-1] numpy

--- a/include/dsplib/czt.h
+++ b/include/dsplib/czt.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "dsplib/types.h"
 #include <dsplib/fft.h>
 #include <memory>
 

--- a/include/dsplib/czt.h
+++ b/include/dsplib/czt.h
@@ -11,7 +11,11 @@ class CztPlan : public FftPlanC
 {
 public:
     explicit CztPlan(int n, int m, cmplx_t w, cmplx_t a = 1);
+
     [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
+
+    void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const final;
+
     [[nodiscard]] int size() const noexcept final;
 
     arr_cmplx operator()(span_t<cmplx_t> x) const {

--- a/include/dsplib/czt.h
+++ b/include/dsplib/czt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dsplib/types.h"
 #include <dsplib/fft.h>
 #include <memory>
 
@@ -11,10 +12,10 @@ class CztPlan : public FftPlanC
 {
 public:
     explicit CztPlan(int n, int m, cmplx_t w, cmplx_t a = 1);
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final;
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
     [[nodiscard]] int size() const noexcept final;
 
-    arr_cmplx operator()(const arr_cmplx& x) const {
+    arr_cmplx operator()(span_t<cmplx_t> x) const {
         return this->solve(x);
     }
 
@@ -30,6 +31,6 @@ private:
 * \param a Spiral contour initial point
 * \return Chirp Z-transform
 */
-arr_cmplx czt(const arr_cmplx& x, int m, cmplx_t w, cmplx_t a = 1);
+arr_cmplx czt(span_t<cmplx_t> x, int m, cmplx_t w, cmplx_t a = 1);
 
 }   // namespace dsplib

--- a/include/dsplib/fft.h
+++ b/include/dsplib/fft.h
@@ -21,14 +21,7 @@ public:
      * @param x [in] input array[n]
      * @param r [out] result array[n]
      */
-    virtual void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const {
-        //default implementation
-        const int n = this->size();
-        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
-        DSPLIB_ASSERT(x.size() == n, "input size error");
-        const auto y = this->solve(x);
-        std::memcpy(r.data(), y.data(), n * sizeof(r[0]));
-    }
+    virtual void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const = 0;
 
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
@@ -48,14 +41,7 @@ public:
      * @param x [in] input array[n]
      * @param r [out] result array[n]
      */
-    virtual void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const {
-        //TODO: support n/2+1 output size
-        const int n = this->size();
-        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
-        DSPLIB_ASSERT(x.size() == n, "input size error");
-        const auto y = this->solve(x);
-        std::memcpy(r.data(), y.data(), n * sizeof(r[0]));
-    }
+    virtual void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const = 0;
 
     [[nodiscard]] virtual int size() const noexcept = 0;
 };

--- a/include/dsplib/fft.h
+++ b/include/dsplib/fft.h
@@ -13,7 +13,23 @@ class FftPlanC
 {
 public:
     virtual ~FftPlanC() = default;
+
     [[nodiscard]] virtual arr_cmplx solve(span_t<cmplx_t> x) const = 0;
+
+    /**
+     * @brief c2c FFT solve
+     * @param x [in] input array[n]
+     * @param r [out] result array[n]
+     */
+    virtual void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const {
+        //default implementation
+        const int n = this->size();
+        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
+        DSPLIB_ASSERT(x.size() == n, "input size error");
+        const auto y = this->solve(x);
+        std::memcpy(r.data(), y.data(), n * sizeof(r[0]));
+    }
+
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 
@@ -24,7 +40,23 @@ class FftPlanR
 {
 public:
     virtual ~FftPlanR() = default;
+
     [[nodiscard]] virtual arr_cmplx solve(span_t<real_t> x) const = 0;
+
+    /**
+     * @brief r2c FFT solve
+     * @param x [in] input array[n]
+     * @param r [out] result array[n]
+     */
+    virtual void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const {
+        //TODO: support n/2+1 output size
+        const int n = this->size();
+        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
+        DSPLIB_ASSERT(x.size() == n, "input size error");
+        const auto y = this->solve(x);
+        std::memcpy(r.data(), y.data(), n * sizeof(r[0]));
+    }
+
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 

--- a/include/dsplib/fft.h
+++ b/include/dsplib/fft.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <dsplib/array.h>
+
 #include <memory>
 
 namespace dsplib {
@@ -60,16 +61,16 @@ std::shared_ptr<FftPlanR> fft_plan_r(int n);
  * @param arr Input array [N]
  * @return Result array [N]
  */
-arr_cmplx fft(const arr_cmplx& x);
+arr_cmplx fft(span_t<cmplx_t> x);
 
 //n-point DFT
 // if x.size() is less than n, then X is padded with trailing zeros to length n
 // if x.size() is greater than n, then x is truncated to length n
-arr_cmplx fft(const arr_cmplx& x, int n);
+arr_cmplx fft(span_t<cmplx_t> x, int n);
 
 //Fast Fourier Transform (real)
-arr_cmplx fft(const arr_real& x);
-arr_cmplx fft(const arr_real& x, int n);
+arr_cmplx fft(span_t<real_t> x);
+arr_cmplx fft(span_t<real_t> x, int n);
 
 arr_cmplx rfft(const arr_real& x);          // equal `fft(x)`
 arr_cmplx rfft(const arr_real& x, int n);   // equal `fft(x, n)`

--- a/include/dsplib/fft.h
+++ b/include/dsplib/fft.h
@@ -13,14 +13,7 @@ class FftPlanC
 {
 public:
     virtual ~FftPlanC() = default;
-
-    [[nodiscard]] virtual arr_cmplx solve(const arr_cmplx& x) const = 0;
-
-    [[deprecated]] virtual void solve(const cmplx_t* x, cmplx_t* y, int n) const {
-        const auto r = this->solve(arr_cmplx(x, n));
-        std::memcpy(y, r.data(), n * sizeof(cmplx_t));
-    }
-
+    [[nodiscard]] virtual arr_cmplx solve(span_t<cmplx_t> x) const = 0;
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 
@@ -31,15 +24,7 @@ class FftPlanR
 {
 public:
     virtual ~FftPlanR() = default;
-
-    [[nodiscard]] virtual arr_cmplx solve(const arr_real& x) const = 0;
-
-    [[deprecated]] virtual void solve(const real_t* x, cmplx_t* y, int n) const {
-        //TODO: use span
-        const auto r = this->solve(arr_real(x, n));
-        std::memcpy(y, r.data(), n * sizeof(cmplx_t));
-    }
-
+    [[nodiscard]] virtual arr_cmplx solve(span_t<real_t> x) const = 0;
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 
@@ -72,7 +57,7 @@ arr_cmplx fft(span_t<cmplx_t> x, int n);
 arr_cmplx fft(span_t<real_t> x);
 arr_cmplx fft(span_t<real_t> x, int n);
 
-arr_cmplx rfft(const arr_real& x);          // equal `fft(x)`
-arr_cmplx rfft(const arr_real& x, int n);   // equal `fft(x, n)`
+arr_cmplx rfft(span_t<real_t> x);          // equal `fft(x)`
+arr_cmplx rfft(span_t<real_t> x, int n);   // equal `fft(x, n)`
 
 }   // namespace dsplib

--- a/include/dsplib/ifft.h
+++ b/include/dsplib/ifft.h
@@ -23,13 +23,7 @@ public:
      * @param x [in] input array[n]
      * @param r [out] result array[n]
      */
-    virtual void solve(span_t<cmplx_t> x, mut_span_t<real_t> r) const {
-        const int n = this->size();
-        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
-        DSPLIB_ASSERT(x.size() == n, "input size error");
-        const auto y = this->solve(x);
-        std::memcpy(r.data(), y.data(), n * sizeof(r[0]));
-    }
+    virtual void solve(span_t<cmplx_t> x, mut_span_t<real_t> r) const = 0;
 
     [[nodiscard]] virtual int size() const noexcept = 0;
 };

--- a/include/dsplib/ifft.h
+++ b/include/dsplib/ifft.h
@@ -15,7 +15,7 @@ class IfftPlanR
 {
 public:
     virtual ~IfftPlanR() = default;
-    [[nodiscard]] virtual arr_real solve(const arr_cmplx& x) const = 0;
+    [[nodiscard]] virtual arr_real solve(span_t<cmplx_t> x) const = 0;
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 
@@ -37,7 +37,7 @@ std::shared_ptr<IfftPlanR> ifft_plan_r(int n);
  * @param x Input array [N]
  * @return Result array [N]
  */
-arr_cmplx ifft(const arr_cmplx& x);
+arr_cmplx ifft(span_t<cmplx_t> x);
 
 /**
  * @brief Inverse real fourier transform
@@ -45,8 +45,8 @@ arr_cmplx ifft(const arr_cmplx& x);
  * @param n Transform size
  * @return Result array [N]
  */
-arr_real irfft(const arr_cmplx& x, int n);
+arr_real irfft(span_t<cmplx_t> x, int n);
 
-arr_real irfft(const arr_cmplx& x);
+arr_real irfft(span_t<cmplx_t> x);
 
 }   // namespace dsplib

--- a/include/dsplib/ifft.h
+++ b/include/dsplib/ifft.h
@@ -15,7 +15,22 @@ class IfftPlanR
 {
 public:
     virtual ~IfftPlanR() = default;
+
     [[nodiscard]] virtual arr_real solve(span_t<cmplx_t> x) const = 0;
+
+    /**
+     * @brief c2r iFFT solve
+     * @param x [in] input array[n]
+     * @param r [out] result array[n]
+     */
+    virtual void solve(span_t<cmplx_t> x, mut_span_t<real_t> r) const {
+        const int n = this->size();
+        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
+        DSPLIB_ASSERT(x.size() == n, "input size error");
+        const auto y = this->solve(x);
+        std::memcpy(r.data(), y.data(), n * sizeof(r[0]));
+    }
+
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 

--- a/include/dsplib/iterator.h
+++ b/include/dsplib/iterator.h
@@ -55,6 +55,14 @@ struct SliceIterator
         return lhs.ptr_ != rhs.ptr_;
     };
 
+    friend bool operator>(const SliceIterator& lhs, const SliceIterator& rhs) noexcept {
+        return lhs.ptr_ > rhs.ptr_;
+    };
+
+    friend bool operator<(const SliceIterator& lhs, const SliceIterator& rhs) noexcept {
+        return lhs.ptr_ < rhs.ptr_;
+    };
+
 private:
     pointer ptr_;
     int step_{1};

--- a/include/dsplib/lms.h
+++ b/include/dsplib/lms.h
@@ -41,9 +41,7 @@ public:
     }
 
     Result process(const base_array<T>& x, const base_array<T>& d) {
-        if (x.size() != d.size()) {
-            DSPLIB_THROW("vector size error: len(x) != len(d)");
-        }
+        DSPLIB_ASSERT(x.size() == d.size(), "vector size error: len(x) != len(d)");
 
         int nx = x.size();
         base_array<T> y(nx);

--- a/include/dsplib/lms.h
+++ b/include/dsplib/lms.h
@@ -46,8 +46,8 @@ public:
         }
 
         int nx = x.size();
-        base_array<T> y = array_cast<T>(zeros(nx));
-        base_array<T> e = array_cast<T>(zeros(nx));
+        base_array<T> y(nx);
+        base_array<T> e(nx);
         base_array<T> tu = _u | x;
         arr_real tu2 = (_method == LmsType::NLMS) ? abs2(tu) : arr_real{};
 

--- a/include/dsplib/lms.h
+++ b/include/dsplib/lms.h
@@ -46,8 +46,8 @@ public:
         }
 
         int nx = x.size();
-        base_array<T> y(nx);
-        base_array<T> e(nx);
+        base_array<T> y = array_cast<T>(zeros(nx));
+        base_array<T> e = array_cast<T>(zeros(nx));
         base_array<T> tu = _u | x;
         arr_real tu2 = (_method == LmsType::NLMS) ? abs2(tu) : arr_real{};
 

--- a/include/dsplib/math.h
+++ b/include/dsplib/math.h
@@ -23,8 +23,8 @@ arr_real tanh(arr_real x);
 arr_cmplx tanh(arr_cmplx x);
 
 //max element
-real_t max(const arr_real& arr);
-cmplx_t max(const arr_cmplx& arr);
+real_t max(span_real arr);
+cmplx_t max(span_cmplx arr);
 
 template<typename T1, typename T2>
 auto max(const T1& v1, const T2& v2) -> decltype(v1 + v2) {
@@ -32,8 +32,8 @@ auto max(const T1& v1, const T2& v2) -> decltype(v1 + v2) {
 }
 
 //min element
-real_t min(const arr_real& arr);
-cmplx_t min(const arr_cmplx& arr);
+real_t min(span_real arr);
+cmplx_t min(span_cmplx arr);
 
 template<typename T1, typename T2>
 auto min(const T1& v1, const T2& v2) -> decltype(v1 + v2) {
@@ -45,12 +45,12 @@ real_t peak2peak(const arr_real& arr);
 cmplx_t peak2peak(const arr_cmplx& arr);
 
 //max element index
-int argmax(const arr_real& arr);
-int argmax(const arr_cmplx& arr);
+int argmax(span_real arr);
+int argmax(span_cmplx arr);
 
 //min element index
-int argmin(const arr_real& arr);
-int argmin(const arr_cmplx& arr);
+int argmin(span_real arr);
+int argmin(span_cmplx arr);
 
 //absolute value and complex magnitude
 arr_real abs(const arr_real& arr);
@@ -129,7 +129,7 @@ constexpr real_t conj(const real_t& x) noexcept {
 
 //complex vector formation
 arr_cmplx complex(const arr_real& re, const arr_real& im);
-arr_cmplx complex(const arr_real& re) noexcept;
+arr_cmplx complex(const arr_real& re);
 
 //the nearest power of two numbers (with rounding up)
 constexpr int nextpow2(int m) noexcept {

--- a/include/dsplib/math.h
+++ b/include/dsplib/math.h
@@ -128,8 +128,8 @@ constexpr real_t conj(const real_t& x) noexcept {
 };
 
 //complex vector formation
-arr_cmplx complex(const arr_real& re, const arr_real& im);
-arr_cmplx complex(const arr_real& re);
+arr_cmplx complex(span_real re, span_real im);
+arr_cmplx complex(span_real re);
 
 //the nearest power of two numbers (with rounding up)
 constexpr int nextpow2(int m) noexcept {

--- a/include/dsplib/rls.h
+++ b/include/dsplib/rls.h
@@ -59,9 +59,7 @@ using RlsFilterC = RlsFilter<cmplx_t>;
 //-----------------------------------------------------------------------------------------------
 template<typename T>
 typename RlsFilter<T>::Result RlsFilter<T>::process(const base_array<T>& x, const base_array<T>& d) {
-    if (x.size() != d.size()) {
-        DSPLIB_THROW("vector size error: len(x) != len(d)");
-    }
+    DSPLIB_ASSERT(x.size() == d.size(), "vector size error: len(x) != len(d)");
 
     const int nx = x.size();
     base_array<T> y(nx);

--- a/include/dsplib/slice.h
+++ b/include/dsplib/slice.h
@@ -17,61 +17,13 @@ class mut_slice_t;
 template<typename T>
 class slice_t;
 
-class base_slice_t
-{
-public:
-    base_slice_t() = default;
-
-    explicit base_slice_t(int n, int i1, int i2, int m)
-      : _m{m}
-      , _n{n}
-      , _i1{(i1 < 0) ? (_n + i1) : (i1)}
-      , _i2{(i2 < 0) ? (_n + i2) : (i2)}
-      , _nc{_count()} {
-        if (_n == 0) {
-            return;
-        }
-
-        DSPLIB_ASSERT(m != 0, "Slice stride cannot be zero");
-        DSPLIB_ASSERT((_i1 >= 0) && (_i1 < _n), "Left slice index out of range");
-        DSPLIB_ASSERT((_i2 >= 0) && (_i2 <= _n), "Right slice index out of range");
-        DSPLIB_ASSERT(!((_m < 0) && (_i1 < _i2)), "First index is smaller for negative step");
-        DSPLIB_ASSERT(!((_m > 0) && (_i1 > _i2)), "First index is greater for positive step");
-        DSPLIB_ASSERT(_nc <= _n, "Slice range is greater array size");
-    }
-
-    bool empty() const noexcept {
-        return (_nc == 0);
-    }
-
-protected:
-    int _m{1};
-    int _n{0};
-    int _i1{0};
-    int _i2{0};
-    int _nc{0};
-
-private:
-    int _count() const noexcept {
-        if (_n == 0) {
-            return 0;
-        }
-        const int d = std::abs(_i2 - _i1);
-        const int tm = std::abs(_m);
-        const int size = (d % tm != 0) ? (d / tm + 1) : (d / tm);
-        return size;
-    }
-};
-
-static_assert(std::is_trivially_copyable<base_slice_t>(), "type must be trivially copyable");
-
 /**
  * @brief Non-mutable slice object
  * @todo add concatenate array = slice | array
  * @tparam T real_t/cmplx_t
  */
 template<typename T>
-class slice_t : public base_slice_t
+class slice_t
 {
 public:
     friend class mut_slice_t<T>;
@@ -79,31 +31,31 @@ public:
 
     slice_t() = default;
 
-    slice_t(const T* data, int size, int i1, int i2, int m)
-      : base_slice_t(size, i1, i2, m)
-      , _data{data} {
-    }
-
     slice_t(const mut_slice_t<T>& rhs)
-      : base_slice_t(rhs._n, rhs._i1, rhs._i2, rhs._m)
-      , _data{rhs._data} {
+      : data_{rhs.data_}
+      , stride_{rhs.stride_}
+      , count_{rhs.count_} {
     }
 
     [[nodiscard]] int size() const noexcept {
-        return _nc;
+        return count_;
+    }
+
+    bool empty() const noexcept {
+        return count_ == 0;
     }
 
     [[nodiscard]] int stride() const noexcept {
-        return _m;
+        return stride_;
     }
 
     const_iterator begin() const noexcept {
-        return const_iterator(_data + _i1, _m);
+        return const_iterator(data_, stride_);
     }
 
     const_iterator end() const noexcept {
         auto current = begin();
-        std::advance(current, _nc);
+        std::advance(current, count_);
         return current;
     }
 
@@ -111,8 +63,22 @@ public:
         return base_array<T>(*this);
     }
 
+    static slice_t make_slice(const T* data, int size, int i1, int i2, int step) {
+        auto mdata = const_cast<T*>(data);
+        return slice_t(mut_slice_t<T>::make_slice(mdata, size, i1, i2, step));
+    }
+
 protected:
-    const T* _data{nullptr};
+    explicit slice_t(const T* data, int stride, int count)
+      : data_{data}
+      , stride_{stride}
+      , count_{count} {
+        DSPLIB_ASSERT(count >= 0, "Count of elements must be positive");
+    }
+
+    const T* data_{nullptr};
+    int stride_{0};
+    int count_{0};
 };
 
 /**
@@ -120,7 +86,7 @@ protected:
  * @tparam T real_t/cmplx_t
  */
 template<typename T>
-class mut_slice_t : public base_slice_t
+class mut_slice_t
 {
 public:
     friend class slice_t<T>;
@@ -129,17 +95,16 @@ public:
 
     mut_slice_t() = default;
 
-    mut_slice_t(T* data, int size, int i1, int i2, int m)
-      : base_slice_t(size, i1, i2, m)
-      , _data{data} {
+    [[nodiscard]] int size() const noexcept {
+        return count_;
     }
 
-    [[nodiscard]] int size() const noexcept {
-        return _nc;
+    bool empty() const noexcept {
+        return count_ == 0;
     }
 
     [[nodiscard]] int stride() const noexcept {
-        return _m;
+        return stride_;
     }
 
     mut_slice_t& operator=(const slice_t<T>& rhs) {
@@ -152,14 +117,14 @@ public:
         }
 
         //simple block copy/move (optimization)
-        const bool is_same = _is_same_array(rhs);
+        const bool is_same = is_same_memory(rhs, slice_t(*this));
         if ((this->stride() == 1) && (rhs.stride() == 1)) {
             const auto* src = &(*rhs.begin());
             auto* dst = &(*begin());
             if (!is_same) {
                 std::memcpy(dst, src, count * sizeof(*src));
             } else {
-                //TODO: check overlap and use memcpy
+                //overlapped
                 std::memmove(dst, src, count * sizeof(*src));
             }
             return *this;
@@ -181,7 +146,7 @@ public:
     }
 
     mut_slice_t& operator=(const base_array<T>& rhs) {
-        DSPLIB_ASSERT(!_is_same_array(rhs.slice(0, rhs.size())), "Assigned array to same slice");
+        DSPLIB_ASSERT(!is_same_memory(rhs.slice(0, rhs.size()), *this), "Assigned array to same slice");
         *this = rhs.slice(0, rhs.size());
         return *this;
     }
@@ -197,22 +162,22 @@ public:
     }
 
     iterator begin() noexcept {
-        return iterator(_data + _i1, _m);
+        return iterator(data_, stride_);
     }
 
     iterator end() noexcept {
         auto current = begin();
-        std::advance(current, _nc);
+        std::advance(current, count_);
         return current;
     }
 
     const_iterator begin() const noexcept {
-        return const_iterator(_data + _i1, _m);
+        return const_iterator(data_, stride_);
     }
 
     const_iterator end() const noexcept {
         auto current = begin();
-        std::advance(current, _nc);
+        std::advance(current, count_);
         return current;
     }
 
@@ -220,16 +185,50 @@ public:
         return base_array<T>(*this);
     }
 
-protected:
-    bool _is_same_array(const slice_t<T>& rhs) const noexcept {
-        auto l1 = _data;
-        auto r1 = _data + _nc;
-        auto l2 = rhs._data;
-        auto r2 = rhs._data + rhs._nc;
-        return ((l2 >= l1) && (l2 <= r1)) || ((r2 >= l1) && (r2 <= r1));
+    static bool is_same_memory(slice_t<T> r1, slice_t<T> r2) noexcept {
+        if (r1.empty() || r2.empty()) {
+            return false;
+        }
+        auto start1 = r1.begin();
+        auto end1 = r1.end();
+        auto start2 = r2.begin();
+        auto end2 = r2.end();
+        return (start1 < end2) && (start2 < end1);
     }
 
-    T* _data{nullptr};
+    static mut_slice_t make_slice(T* data, int size, int i1, int i2, int step) {
+        if (size == 0) {
+            return mut_slice_t();
+        }
+
+        i1 = (i1 < 0) ? (size + i1) : i1;
+        i2 = (i2 < 0) ? (size + i2) : i2;
+
+        const int d = std::abs(i2 - i1);
+        const int tm = std::abs(step);
+        int count = (d % tm != 0) ? (d / tm + 1) : (d / tm);
+
+        DSPLIB_ASSERT(step != 0, "Slice stride cannot be zero");
+        DSPLIB_ASSERT((i1 >= 0) && (i1 < size), "Left slice index out of range");
+        DSPLIB_ASSERT((i2 >= 0) && (i2 <= size), "Right slice index out of range");
+        DSPLIB_ASSERT(!((step < 0) && (i1 < i2)), "First index is smaller for negative step");
+        DSPLIB_ASSERT(!((step > 0) && (i1 > i2)), "First index is greater for positive step");
+        DSPLIB_ASSERT(count <= size, "Slice range is greater array size");
+
+        return mut_slice_t(data + i1, step, count);
+    }
+
+protected:
+    explicit mut_slice_t(T* data, int stride, int count)
+      : data_{data}
+      , stride_{stride}
+      , count_{count} {
+        DSPLIB_ASSERT(count >= 0, "Count of elements must be positive");
+    }
+
+    T* data_{nullptr};
+    int stride_{0};
+    int count_{0};
 };
 
 }   // namespace dsplib

--- a/include/dsplib/slice.h
+++ b/include/dsplib/slice.h
@@ -20,11 +20,18 @@ template<typename T>
 class const_slice_t;
 
 //----------------------------------------------------------------------------------------
+//TODO: support empty slices
 class base_slice_t
 {
 public:
+    base_slice_t() = default;
+
     explicit base_slice_t(int n, int i1, int i2, int m) {
-        DSPLIB_ASSERT(n != 0, "Slicing from an empty array");
+        //is empty
+        if (n == 0) {
+            return;
+        }
+
         DSPLIB_ASSERT(m != 0, "Slice stride cannot be zero");
 
         _m = m;
@@ -56,6 +63,10 @@ public:
         }
     }
 
+    bool empty() const noexcept {
+        return (_nc == 0);
+    }
+
 protected:
     int _i1{0};
     int _i2{0};
@@ -72,6 +83,8 @@ class const_slice_t : public base_slice_t
 public:
     friend class slice_t<T>;
     using const_iterator = SliceIterator<const T>;
+
+    const_slice_t() = default;
 
     const_slice_t(const T* data, int size, int i1, int i2, int m)
       : base_slice_t(size, i1, i2, m)
@@ -122,6 +135,8 @@ public:
     friend class const_slice_t<T>;
     using iterator = SliceIterator<T>;
     using const_iterator = SliceIterator<const T>;
+
+    slice_t() = default;
 
     slice_t(T* data, int size, int i1, int i2, int m)
       : base_slice_t(size, i1, i2, m)

--- a/include/dsplib/slice.h
+++ b/include/dsplib/slice.h
@@ -45,11 +45,11 @@ public:
     }
 
 protected:
-    const int _m{1};
-    const int _n{0};
-    const int _i1{0};
-    const int _i2{0};
-    const int _nc{0};
+    int _m{1};
+    int _n{0};
+    int _i1{0};
+    int _i2{0};
+    int _nc{0};
 
 private:
     int _count() const noexcept {
@@ -62,6 +62,8 @@ private:
         return size;
     }
 };
+
+static_assert(std::is_trivially_copyable<base_slice_t>(), "type must be trivially copyable");
 
 /**
  * @brief Non-mutable slice object
@@ -80,11 +82,6 @@ public:
     slice_t(const T* data, int size, int i1, int i2, int m)
       : base_slice_t(size, i1, i2, m)
       , _data{data} {
-    }
-
-    slice_t(const slice_t& rhs)
-      : base_slice_t(rhs.size(), rhs._i1, rhs._i2, rhs._m)
-      , _data{rhs._data} {
     }
 
     slice_t(const mut_slice_t<T>& rhs)
@@ -135,11 +132,6 @@ public:
     mut_slice_t(T* data, int size, int i1, int i2, int m)
       : base_slice_t(size, i1, i2, m)
       , _data{data} {
-    }
-
-    mut_slice_t(const mut_slice_t& rhs)
-      : base_slice_t(rhs._n, rhs._i1, rhs._i2, rhs._m)
-      , _data{rhs._data} {
     }
 
     [[nodiscard]] int size() const noexcept {

--- a/include/dsplib/slice.h
+++ b/include/dsplib/slice.h
@@ -31,6 +31,12 @@ public:
 
     slice_t() = default;
 
+    slice_t(const slice_t& rhs)
+      : data_{rhs.data_}
+      , stride_{rhs.stride_}
+      , count_{rhs.count_} {
+    }
+
     slice_t(const mut_slice_t<T>& rhs)
       : data_{rhs.data_}
       , stride_{rhs.stride_}
@@ -94,6 +100,12 @@ public:
     using const_iterator = SliceIterator<const T>;
 
     mut_slice_t() = default;
+
+    mut_slice_t(const mut_slice_t& rhs)
+      : data_{rhs.data_}
+      , stride_{rhs.stride_}
+      , count_{rhs.count_} {
+    }
 
     [[nodiscard]] int size() const noexcept {
         return count_;

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -32,13 +32,11 @@ public:
     friend class span_t<T>;
 
     explicit mut_span_t(T* data, int size)
-      : mut_slice_t<T>(data, size, 0, size, 1)
-      , data_{data}
-      , len_{size} {
+      : mut_slice_t<T>{data, 1, size} {
     }
 
     mut_span_t(const mut_span_t& v)
-      : mut_span_t(v.data_, v.len_) {
+      : mut_span_t(v.data_, v.count_) {
     }
 
     mut_span_t(base_array<T>& v)
@@ -50,20 +48,20 @@ public:
     }
 
     [[nodiscard]] T* data() noexcept {
-        return data_;
+        return this->data_;
     }
 
     [[nodiscard]] const T* data() const noexcept {
-        return data_;
+        return this->data_;
     }
 
     [[nodiscard]] int size() const noexcept {
-        return len_;
+        return this->count_;
     }
 
     T& operator[](int i) noexcept {
-        assert((i >= 0) && (i < len_));
-        return data_[i];
+        assert((i >= 0) && (i < size()));
+        return this->data_[i];
     }
 
     //TODO: override fast implementation for span
@@ -94,7 +92,7 @@ public:
     }
 
     mut_span_t& operator=(const T& rhs) {
-        std::fill(data_, (data_ + len_), rhs);
+        std::fill(this->data_, (this->data_ + this->count_), rhs);
         return *this;
     }
 
@@ -107,31 +105,27 @@ public:
     using const_iterator = const T*;
 
     iterator begin() noexcept {
-        return data_;
+        return this->data_;
     }
 
     iterator end() noexcept {
-        return data_ + len_;
+        return this->data_ + this->count_;
     }
 
     const_iterator begin() const noexcept {
-        return data_;
+        return this->data_;
     }
 
     const_iterator end() const noexcept {
-        return data_ + len_;
+        return this->data_ + this->count_;
     }
 
     //TODO: add more checks
     mut_span_t slice(int i1, int i2) const {
-        DSPLIB_ASSERT((i1 >= 0) && (i1 < len_), "invalid range");
-        DSPLIB_ASSERT((i2 > i1) && (i2 <= len_), "invalid range");
-        return mut_span_t(data_ + i1, (i2 - i1));
+        DSPLIB_ASSERT((i1 >= 0) && (i1 < this->count_), "invalid range");
+        DSPLIB_ASSERT((i2 > i1) && (i2 <= this->count_), "invalid range");
+        return mut_span_t(this->data_ + i1, (i2 - i1));
     }
-
-private:
-    T* data_{nullptr};
-    const int len_{0};
 };
 
 //immutable span
@@ -146,9 +140,7 @@ public:
     span_t() = default;
 
     explicit span_t(const T* data, int size)
-      : slice_t<T>(data, size, 0, size, 1)
-      , data_{data}
-      , len_{size} {
+      : slice_t<T>{data, 1, size} {
     }
 
     span_t(const mut_span_t<T>& v)
@@ -164,37 +156,33 @@ public:
     }
 
     [[nodiscard]] const T* data() const noexcept {
-        return data_;
+        return this->data_;
     }
 
     [[nodiscard]] int size() const noexcept {
-        return len_;
+        return this->count_;
     }
 
     const T& operator[](int i) const noexcept {
-        assert((i >= 0) && (i < len_));
-        return data_[i];
+        assert((i >= 0) && (i < size()));
+        return this->data_[i];
     }
 
     using const_iterator = const T*;
 
     const_iterator begin() const noexcept {
-        return data_;
+        return this->data_;
     }
 
     const_iterator end() const noexcept {
-        return data_ + len_;
+        return this->data_ + this->count_;
     }
 
     span_t slice(int i1, int i2) const {
-        DSPLIB_ASSERT((i1 >= 0) && (i1 < len_), "invalid range");
-        DSPLIB_ASSERT((i2 > i1) && (i2 <= len_), "invalid range");
-        return span_t(data_ + i1, (i2 - i1));
+        DSPLIB_ASSERT((i1 >= 0) && (i1 < this->count_), "invalid range");
+        DSPLIB_ASSERT((i2 > i1) && (i2 <= this->count_), "invalid range");
+        return span_t(this->data_ + i1, (i2 - i1));
     }
-
-private:
-    const T* data_{nullptr};
-    const int len_{0};
 };
 
 //------------------------------------------------------------------------------------------------

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <dsplib/throw.h>
+#include <dsplib/types.h>
 #include <dsplib/slice.h>
+
 #include <cassert>
+#include <vector>
 
 namespace dsplib {
 
@@ -106,6 +110,13 @@ public:
         return _ptr + _len;
     }
 
+    //TODO: add more checks
+    mut_span_t slice(int i1, int i2) const {
+        DSPLIB_ASSERT((i1 >= 0) && (i1 < _len), "invalid range");
+        DSPLIB_ASSERT((i2 > i1) && (i2 <= _len), "invalid range");
+        return mut_span_t(_ptr + i1, (i2 - i1));
+    }
+
 private:
     T* _ptr{nullptr};
     int _len{0};
@@ -164,15 +175,52 @@ public:
         return _ptr + _len;
     }
 
+    span_t slice(int i1, int i2) const {
+        DSPLIB_ASSERT((i1 >= 0) && (i1 < _len), "invalid range");
+        DSPLIB_ASSERT((i2 > i1) && (i2 <= _len), "invalid range");
+        return span_t(_ptr + i1, (i2 - i1));
+    }
+
 private:
     const T* _ptr{nullptr};
     int _len{0};
 };
 
-//TODO: short naming, mut_span_r/mut_span_c or m_span_r/m_span_c
-using mut_span_real = mut_span_t<real_t>;
-using mut_span_cmplx = mut_span_t<cmplx_t>;
+//------------------------------------------------------------------------------------------------
+//TODO: rename to `make_span`?
+template<typename T>
+span_t<T> span(const T* x, int nx) noexcept {
+    return span_t<T>(x, nx);
+}
 
+template<typename T>
+mut_span_t<T> span(T* x, int nx) noexcept {
+    return mut_span_t<T>(x, nx);
+}
+
+//------------------------------------------------------------------------------------------------
+template<typename T>
+span_t<T> span(const std::vector<T>& x) noexcept {
+    return span_t<T>(x.data(), x.size());
+}
+
+template<typename T>
+mut_span_t<T> span(std::vector<T>& x) noexcept {
+    return mut_span_t<T>(x.data(), x.size());
+}
+
+//------------------------------------------------------------------------------------------------
+template<typename T>
+span_t<T> span(const base_array<T>& x) noexcept {
+    return span_t<T>(x.data(), x.size());
+}
+
+template<typename T>
+mut_span_t<T> span(base_array<T>& x) noexcept {
+    return mut_span_t<T>(x.data(), x.size());
+}
+
+//TODO: short naming, span_r/span_c?
 using span_real = span_t<real_t>;
 using span_cmplx = span_t<cmplx_t>;
 

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -23,17 +23,19 @@ class span_t;
 
 //mutable span
 template<typename T>
-class mut_span_t : public slice_t<T>
+class mut_span_t : public mut_slice_t<T>
 {
 public:
     friend class span_t<T>;
 
-    mut_span_t() = default;
-
     explicit mut_span_t(T* data, int size)
-      : slice_t<T>(data, size, 0, size, 1)
+      : mut_slice_t<T>(data, size, 0, size, 1)
       , _ptr{data}
       , _len{size} {
+    }
+
+    mut_span_t(const mut_span_t& v)
+      : mut_span_t(v._ptr, v._len) {
     }
 
     mut_span_t(base_array<T>& v)
@@ -63,18 +65,28 @@ public:
 
     //TODO: override fast implementation for span
 
-    mut_span_t& operator=(const const_slice_t<T>& rhs) {
-        slice_t<T>::operator=(rhs);
+    mut_span_t& operator=(const mut_span_t& rhs) {
+        if (this == &rhs) {
+            return *this;
+        }
+        mut_slice_t<T>::operator=(rhs);
         return *this;
     }
 
     mut_span_t& operator=(const slice_t<T>& rhs) {
-        slice_t<T>::operator=(rhs);
+        //TODO: check if slice ~ span (but check overlap memory)
+        mut_slice_t<T>::operator=(rhs);
+        return *this;
+    }
+
+    mut_span_t& operator=(const mut_slice_t<T>& rhs) {
+        //TODO: check if slice ~ span
+        mut_slice_t<T>::operator=(rhs);
         return *this;
     }
 
     mut_span_t& operator=(const base_array<T>& rhs) {
-        slice_t<T>::operator=(rhs);
+        *this = span_t<T>(rhs.data(), rhs.size());
         return *this;
     }
 
@@ -84,7 +96,7 @@ public:
     }
 
     mut_span_t& operator=(const std::initializer_list<T>& rhs) {
-        slice_t<T>::operator=(rhs);
+        mut_slice_t<T>::operator=(rhs);
         return *this;
     }
 
@@ -116,12 +128,12 @@ public:
 
 private:
     T* _ptr{nullptr};
-    int _len{0};
+    const int _len{0};
 };
 
 //immutable span
 template<typename T>
-class span_t : public const_slice_t<T>
+class span_t : public slice_t<T>
 {
 public:
     friend class mut_span_t<T>;
@@ -129,7 +141,7 @@ public:
     span_t() = default;
 
     explicit span_t(const T* data, int size)
-      : const_slice_t<T>(data, size, 0, size, 1)
+      : slice_t<T>(data, size, 0, size, 1)
       , _ptr{data}
       , _len{size} {
     }
@@ -177,7 +189,7 @@ public:
 
 private:
     const T* _ptr{nullptr};
-    int _len{0};
+    const int _len{0};
 };
 
 //------------------------------------------------------------------------------------------------

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -20,6 +20,7 @@ class span_t;
 
 //TODO: add concatenate syntax
 //TODO: add math operators (+,-,*,/)
+//TODO: remove slice_t inheritance
 
 //mutable span
 template<typename T>
@@ -48,10 +49,6 @@ public:
       : mut_span_t(v.data(), v.size()) {
     }
 
-    //TODO: allow or not?
-    // mut_span_t(base_array<T>&& v) = delete;
-    // mut_span_t(std::vector<T>&& v) = delete;
-
     [[nodiscard]] T* data() noexcept {
         return data_;
     }
@@ -75,7 +72,7 @@ public:
         if (this == &rhs) {
             return *this;
         }
-        mut_slice_t<T>::operator=(rhs);
+        mut_slice_t<T>::operator=(slice_t<T>(rhs));
         return *this;
     }
 
@@ -166,9 +163,6 @@ public:
       : span_t(v.data(), v.size()) {
     }
 
-    // span_t(base_array<T>&& v) = delete;
-    // span_t(std::vector<T>&& v) = delete;
-
     [[nodiscard]] const T* data() const noexcept {
         return data_;
     }
@@ -204,36 +198,33 @@ private:
 };
 
 //------------------------------------------------------------------------------------------------
-//TODO: rename to `make_span`?
 template<typename T>
-span_t<T> span(const T* x, int nx) noexcept {
+span_t<T> make_span(const T* x, int nx) noexcept {
     return span_t<T>(x, nx);
 }
 
 template<typename T>
-mut_span_t<T> span(T* x, int nx) noexcept {
+mut_span_t<T> make_span(T* x, int nx) noexcept {
     return mut_span_t<T>(x, nx);
 }
 
-//------------------------------------------------------------------------------------------------
 template<typename T>
-span_t<T> span(const std::vector<T>& x) noexcept {
+span_t<T> make_span(const std::vector<T>& x) noexcept {
     return span_t<T>(x.data(), x.size());
 }
 
 template<typename T>
-mut_span_t<T> span(std::vector<T>& x) noexcept {
+mut_span_t<T> make_span(std::vector<T>& x) noexcept {
     return mut_span_t<T>(x.data(), x.size());
 }
 
-//------------------------------------------------------------------------------------------------
 template<typename T>
-span_t<T> span(const base_array<T>& x) noexcept {
+span_t<T> make_span(const base_array<T>& x) noexcept {
     return span_t<T>(x.data(), x.size());
 }
 
 template<typename T>
-mut_span_t<T> span(base_array<T>& x) noexcept {
+mut_span_t<T> make_span(base_array<T>& x) noexcept {
     return mut_span_t<T>(x.data(), x.size());
 }
 

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -28,6 +28,8 @@ class mut_span_t : public slice_t<T>
 public:
     friend class span_t<T>;
 
+    mut_span_t() = default;
+
     explicit mut_span_t(T* data, int size)
       : slice_t<T>(data, size, 0, size, 1)
       , _ptr{data}
@@ -128,6 +130,8 @@ class span_t : public const_slice_t<T>
 {
 public:
     friend class mut_span_t<T>;
+
+    span_t() = default;
 
     explicit span_t(const T* data, int size)
       : const_slice_t<T>(data, size, 0, size, 1)

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -64,8 +64,6 @@ public:
         return this->data_[i];
     }
 
-    //TODO: override fast implementation for span
-
     mut_span_t& operator=(const mut_span_t& rhs) {
         if (this == &rhs) {
             return *this;
@@ -74,14 +72,13 @@ public:
         return *this;
     }
 
+    //TODO: override fast implementation for span
     mut_span_t& operator=(const slice_t<T>& rhs) {
-        //TODO: check if slice ~ span (but check overlap memory)
         mut_slice_t<T>::operator=(rhs);
         return *this;
     }
 
     mut_span_t& operator=(const mut_slice_t<T>& rhs) {
-        //TODO: check if slice ~ span
         mut_slice_t<T>::operator=(rhs);
         return *this;
     }
@@ -216,7 +213,6 @@ mut_span_t<T> make_span(base_array<T>& x) noexcept {
     return mut_span_t<T>(x.data(), x.size());
 }
 
-//TODO: short naming, span_r/span_c?
 using span_real = span_t<real_t>;
 using span_cmplx = span_t<cmplx_t>;
 

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -15,8 +15,7 @@ class span_t;
 //used to quickly access vector elements in functions (without memory allocation)
 
 //TODO: add concatenate syntax
-//TODO: add math operators
-//TODO: std::vector<T> support (without 'base_array' or use reference to vec_)
+//TODO: add math operators (+,-,*,/)
 
 //mutable span
 template<typename T>
@@ -88,6 +87,25 @@ public:
         return *this;
     }
 
+    using iterator = T*;
+    using const_iterator = const T*;
+
+    iterator begin() noexcept {
+        return _ptr;
+    }
+
+    iterator end() noexcept {
+        return _ptr + _len;
+    }
+
+    const_iterator begin() const noexcept {
+        return _ptr;
+    }
+
+    const_iterator end() const noexcept {
+        return _ptr + _len;
+    }
+
 private:
     T* _ptr{nullptr};
     int _len{0};
@@ -104,10 +122,6 @@ public:
       : const_slice_t<T>(data, size, 0, size, 1)
       , _ptr{data}
       , _len{size} {
-    }
-
-    span_t(const span_t<T>& v)
-      : span_t(v._data, v._i1, v._i2) {
     }
 
     span_t(const mut_span_t<T>& v)
@@ -140,11 +154,22 @@ public:
         return _ptr[i];
     }
 
+    using const_iterator = const T*;
+
+    const_iterator begin() const noexcept {
+        return _ptr;
+    }
+
+    const_iterator end() const noexcept {
+        return _ptr + _len;
+    }
+
 private:
     const T* _ptr{nullptr};
     int _len{0};
 };
 
+//TODO: short naming, mut_span_r/mut_span_c or m_span_r/m_span_c
 using mut_span_real = mut_span_t<real_t>;
 using mut_span_cmplx = mut_span_t<cmplx_t>;
 

--- a/include/dsplib/span.h
+++ b/include/dsplib/span.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <dsplib/throw.h>
+#include <dsplib/assert.h>
 #include <dsplib/types.h>
 #include <dsplib/slice.h>
 
@@ -54,11 +54,6 @@ public:
 
     [[nodiscard]] int size() const noexcept {
         return _len;
-    }
-
-    T& operator()(int i) noexcept {
-        assert((i >= 0) && (i < _len));
-        return _ptr[i];
     }
 
     T& operator[](int i) noexcept {
@@ -157,11 +152,6 @@ public:
 
     [[nodiscard]] int size() const noexcept {
         return _len;
-    }
-
-    const T& operator()(int i) const noexcept {
-        assert((i >= 0) && (i < _len));
-        return _ptr[i];
     }
 
     const T& operator[](int i) const noexcept {

--- a/include/dsplib/types.h
+++ b/include/dsplib/types.h
@@ -39,6 +39,8 @@ constexpr std::complex<T> operator-(const std::complex<T>& lhs, const int& rhs) 
 
 namespace dsplib {
 
+using namespace std::complex_literals;
+
 //-------------------------------------------------------------------------------------------------
 //base scalar type
 #ifdef DSPLIB_USE_FLOAT32

--- a/include/dsplib/types.h
+++ b/include/dsplib/types.h
@@ -262,4 +262,7 @@ constexpr cmplx_t operator/(const T& lhs, const cmplx_t& rhs) {
     return cmplx_t(lhs) / rhs;
 }
 
+static_assert(std::is_trivially_copyable<real_t>(), "type must be trivially copyable");
+static_assert(std::is_trivially_copyable<cmplx_t>(), "type must be trivially copyable");
+
 }   // namespace dsplib

--- a/include/dsplib/utils.h
+++ b/include/dsplib/utils.h
@@ -126,9 +126,7 @@ template<typename T>
 
 template<typename T>
 [[deprecated]] inline arr_cmplx to_complex(const T* x, size_t nx) {
-    if (nx % 2 != 0) {
-        DSPLIB_THROW("Array size is not even");
-    }
+    DSPLIB_ASSERT(nx % 2 == 0, "Array size is not even");
     const T* p = x;
     arr_cmplx r(nx / 2);
     for (auto i = 0; i < r.size(); i++) {

--- a/include/dsplib/utils.h
+++ b/include/dsplib/utils.h
@@ -59,28 +59,9 @@ template<typename T1, typename T2, typename T3, class R = typename enable_if_som
 }
 
 //join a sequence of arrays
-//TODO: add impl for slice/span
-template<class T>
-T concatenate(const T& a1, const T& a2, const T& a3 = T(), const T& a4 = T(), const T& a5 = T()) {
-    std::array<const T*, 5> arrays{&a1, &a2, &a3, &a4, &a5};
-
-    size_t nr = 0;
-    for (auto array : arrays) {
-        nr += array->size();
-    }
-
-    T r(nr);
-    auto* pr = r.data();
-    for (auto array : arrays) {
-        const auto* pa = array->data();
-        for (int i = 0; i < array->size(); ++i) {
-            *pr = pa[i];
-            pr++;
-        }
-    }
-
-    return r;
-}
+//TODO: add slice args?
+arr_real concatenate(span_real x1, span_real x2, span_real x3 = {}, span_real x4 = {}, span_real x5 = {});
+arr_cmplx concatenate(span_cmplx x1, span_cmplx x2, span_cmplx x3 = {}, span_cmplx x4 = {}, span_cmplx x5 = {});
 
 //create array of all zeros
 inline arr_real zeros(int n) {

--- a/include/dsplib/utils.h
+++ b/include/dsplib/utils.h
@@ -59,7 +59,7 @@ template<typename T1, typename T2, typename T3, class R = typename enable_if_som
 }
 
 //join a sequence of arrays
-//TODO: add impl for slices
+//TODO: add impl for slice/span
 template<class T>
 T concatenate(const T& a1, const T& a2, const T& a3 = T(), const T& a4 = T(), const T& a5 = T()) {
     std::array<const T*, 5> arrays{&a1, &a2, &a3, &a4, &a5};
@@ -121,19 +121,19 @@ arr_real from_file(const std::string& file, dtype type = dtype::int16, endian or
 
 //----------------------------------------------------------------------------------------------------------
 template<typename T>
-inline arr_real to_real(const T* x, size_t nx) {
+[[deprecated]] inline arr_real to_real(const T* x, size_t nx) {
     return dsplib::arr_real(x, nx);
 }
 
 //----------------------------------------------------------------------------------------------------------
 template<typename T>
-inline arr_real to_real(const std::vector<T>& arr) {
+[[deprecated]] inline arr_real to_real(const std::vector<T>& arr) {
     return dsplib::arr_real(arr);
 }
 
 //----------------------------------------------------------------------------------------------------------
 template<typename T>
-inline std::vector<T> from_real(const arr_real& arr) {
+[[deprecated]] inline std::vector<T> from_real(const arr_real& arr) {
     static_assert(std::is_convertible<real_t, T>::value, "Type is not convertible");
     static_assert(is_scalar_v<T>, "Type is not scalar");
     std::vector<T> res(arr.size());
@@ -144,11 +144,10 @@ inline std::vector<T> from_real(const arr_real& arr) {
 }
 
 template<typename T>
-inline arr_cmplx to_complex(const T* x, size_t nx) {
+[[deprecated]] inline arr_cmplx to_complex(const T* x, size_t nx) {
     if (nx % 2 != 0) {
         DSPLIB_THROW("Array size is not even");
     }
-
     const T* p = x;
     arr_cmplx r(nx / 2);
     for (auto i = 0; i < r.size(); i++) {
@@ -159,13 +158,13 @@ inline arr_cmplx to_complex(const T* x, size_t nx) {
 }
 
 template<typename T>
-inline arr_cmplx to_complex(const std::vector<T>& arr) {
+[[deprecated]] inline arr_cmplx to_complex(const std::vector<T>& arr) {
     static_assert(is_scalar_v<T>, "Type is not scalar");
     return to_complex(arr.data(), arr.size());
 }
 
 template<typename T>
-inline std::vector<T> from_complex(const arr_cmplx& arr) {
+[[deprecated]] inline std::vector<T> from_complex(const arr_cmplx& arr) {
     static_assert(is_scalar_v<T>, "Type is not scalar");
     static_assert(std::is_convertible<real_t, T>::value, "Type is not convertible");
     std::vector<T> res(arr.size() * 2);
@@ -176,18 +175,9 @@ inline std::vector<T> from_complex(const arr_cmplx& arr) {
     return res;
 }
 
-template<typename T>
-inline base_array<T> zeropad(const base_array<T>& x, int n) {
-    if (x.size() > n) {
-        DSPLIB_THROW("padding size error");
-    }
-
-    if (x.size() == n) {
-        return x;
-    }
-
-    return x | zeros(n - x.size());
-}
+//add zeros to the end of the array
+arr_real zeropad(span_t<real_t> x, int n);
+arr_cmplx zeropad(span_t<cmplx_t> x, int n);
 
 //delays or advances the signal by the number of samples specified in delay
 //TODO: fractional delay support

--- a/lib/czt.cpp
+++ b/lib/czt.cpp
@@ -38,7 +38,7 @@ public:
         }
 
         const arr_cmplx dp = chirp.slice(0, m + n - 1);
-        _ich = _fft2->solve((1.0 / dp) | zeros(n2 - m - n + 1));
+        _ich = _fft2->solve(zeropad((1.0 / dp), n2));
         _rp = chirp.slice(_n - 1, _m + _n - 1);
     }
 

--- a/lib/czt.cpp
+++ b/lib/czt.cpp
@@ -42,7 +42,7 @@ public:
         _rp = chirp.slice(_n - 1, _m + _n - 1);
     }
 
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const {
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const {
         DSPLIB_ASSERT(x.size() == _n, "input size must be equal CZT base");
         arr_cmplx xp(_fft2->size());
         for (int i = 0; i < _n; ++i) {
@@ -69,7 +69,7 @@ CztPlan::CztPlan(int n, int m, cmplx_t w, cmplx_t a)
   : _d{std::make_shared<CztPlanImpl>(n, m, w, a)} {
 }
 
-arr_cmplx CztPlan::solve(const arr_cmplx& x) const {
+arr_cmplx CztPlan::solve(span_t<cmplx_t> x) const {
     return _d->solve(x);
 }
 
@@ -77,7 +77,7 @@ int CztPlan::size() const noexcept {
     return _d->_n;
 }
 
-arr_cmplx czt(const arr_cmplx& x, int m, cmplx_t w, cmplx_t a) {
+arr_cmplx czt(span_t<cmplx_t> x, int m, cmplx_t w, cmplx_t a) {
     CztPlan plan(x.size(), m, w, a);
     return plan.solve(x);
 }

--- a/lib/detector.cpp
+++ b/lib/detector.cpp
@@ -66,9 +66,7 @@ public:
     }
 
     std::optional<PreambleDetector::Result> process(const arr_cmplx& sig) {
-        if (sig.size() % frame_len() != 0) {
-            DSPLIB_THROW("Frame len not supported");
-        }
+        DSPLIB_ASSERT(sig.size() % frame_len() == 0, "Frame len not supported");
 
         const auto cx = _corr_flt.process(sig);
         const auto pwx = _pow_flt.process(abs2(sig));

--- a/lib/fft.cpp
+++ b/lib/fft.cpp
@@ -4,12 +4,12 @@
 
 namespace dsplib {
 
-arr_cmplx fft(const arr_cmplx& x) {
+arr_cmplx fft(span_t<cmplx_t> x) {
     auto plan = fft_plan_c(x.size());
     return plan->solve(x);
 }
 
-arr_cmplx fft(const arr_cmplx& x, int n) {
+arr_cmplx fft(span_t<cmplx_t> x, int n) {
     if (n == x.size()) {
         return fft(x);
     }
@@ -19,12 +19,12 @@ arr_cmplx fft(const arr_cmplx& x, int n) {
     return fft(x.slice(0, n));
 }
 
-arr_cmplx fft(const arr_real& x) {
+arr_cmplx fft(span_t<real_t> x) {
     auto plan = fft_plan_r(x.size());
     return plan->solve(x);
 }
 
-arr_cmplx fft(const arr_real& x, int n) {
+arr_cmplx fft(span_t<real_t> x, int n) {
     if (n == x.size()) {
         return fft(x);
     }
@@ -34,11 +34,11 @@ arr_cmplx fft(const arr_real& x, int n) {
     return fft(x.slice(0, n));
 }
 
-arr_cmplx rfft(const arr_real& x) {
+arr_cmplx rfft(span_t<real_t> x) {
     return fft(x);
 }
 
-arr_cmplx rfft(const arr_real& x, int n) {
+arr_cmplx rfft(span_t<real_t> x, int n) {
     return fft(x, n);
 }
 

--- a/lib/fft/cmplx-ifft.h
+++ b/lib/fft/cmplx-ifft.h
@@ -11,9 +11,10 @@ public:
       : fft_{fft_plan_c(n)} {
     }
 
-    arr_cmplx solve(const arr_cmplx& x) const final {
+    arr_cmplx solve(span_t<cmplx_t> x) const final {
         const real_t m = real_t(1) / x.size();
-        arr_cmplx y = x * m;
+        arr_cmplx y(x);
+        y *= m;
         _inplace_conj(y);
         y = fft_->solve(y);
         _inplace_conj(y);

--- a/lib/fft/fact-fft.cpp
+++ b/lib/fft/fact-fft.cpp
@@ -132,7 +132,7 @@ void _facfft(const PlanTree* plan, cmplx_t* restrict x, cmplx_t* restrict mem, c
 
     if (!plan->has_next()) {
         //TODO: inplace fft
-        plan->solver()->solve(span(x, n), span(mem, n));
+        plan->solver()->solve(make_span(x, n), make_span(mem, n));
         std::memcpy(x, mem, n * sizeof(cmplx_t));
         return;
     }

--- a/lib/fft/fact-fft.cpp
+++ b/lib/fft/fact-fft.cpp
@@ -131,9 +131,11 @@ void _facfft(const PlanTree* plan, cmplx_t* restrict x, cmplx_t* restrict mem, c
     const int n = plan->size();
 
     if (!plan->has_next()) {
-        //TODO: span
-        plan->solver()->solve(x, mem, n);
-        std::memcpy(x, mem, n * sizeof(cmplx_t));
+        //TODO: plan->solver()->solve(x, mem, n);
+        // std::memcpy(x, mem, n * sizeof(cmplx_t));
+        //TODO: inplace fft
+        const auto y = plan->solver()->solve(span(x, n));
+        std::memcpy(x, y.data(), n * sizeof(cmplx_t));
         return;
     }
 

--- a/lib/fft/fact-fft.cpp
+++ b/lib/fft/fact-fft.cpp
@@ -131,6 +131,7 @@ void _facfft(const PlanTree* plan, cmplx_t* restrict x, cmplx_t* restrict mem, c
     const int n = plan->size();
 
     if (!plan->has_next()) {
+        //TODO: span
         plan->solver()->solve(x, mem, n);
         std::memcpy(x, mem, n * sizeof(cmplx_t));
         return;
@@ -180,7 +181,7 @@ FactorFFTPlan::FactorFFTPlan(int n)
     _plan = std::make_shared<PlanTree>(n);
 }
 
-[[nodiscard]] arr_cmplx FactorFFTPlan::solve(const arr_cmplx& x) const {
+[[nodiscard]] arr_cmplx FactorFFTPlan::solve(span_t<cmplx_t> x) const {
     DSPLIB_ASSERT(x.size() == _n, "input vector size is not equal fft size");
     arr_cmplx r(x);   //TODO: remove copy
     _facfft(_plan.get(), r.data(), _px.data(), _twiddle.data(), _n);

--- a/lib/fft/fact-fft.cpp
+++ b/lib/fft/fact-fft.cpp
@@ -131,11 +131,9 @@ void _facfft(const PlanTree* plan, cmplx_t* restrict x, cmplx_t* restrict mem, c
     const int n = plan->size();
 
     if (!plan->has_next()) {
-        //TODO: plan->solver()->solve(x, mem, n);
-        // std::memcpy(x, mem, n * sizeof(cmplx_t));
         //TODO: inplace fft
-        const auto y = plan->solver()->solve(span(x, n));
-        std::memcpy(x, y.data(), n * sizeof(cmplx_t));
+        plan->solver()->solve(span(x, n), span(mem, n));
+        std::memcpy(x, mem, n * sizeof(cmplx_t));
         return;
     }
 

--- a/lib/fft/fact-fft.h
+++ b/lib/fft/fact-fft.h
@@ -16,7 +16,7 @@ class FactorFFTPlan : public FftPlanC
 public:
     explicit FactorFFTPlan(int n);
     ~FactorFFTPlan() = default;
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final;
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:
@@ -35,7 +35,7 @@ public:
 
     ~FactorFFTPlanR() = default;
 
-    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
+    [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final {
         //TODO: real optimization (for odd sizes)
         return _plan.solve(complex(x));
     }

--- a/lib/fft/fact-fft.h
+++ b/lib/fft/fact-fft.h
@@ -2,6 +2,7 @@
 
 #include <dsplib/math.h>
 #include <dsplib/fft.h>
+#include <dsplib/math.h>
 
 #include <memory>
 

--- a/lib/fft/fact-fft.h
+++ b/lib/fft/fact-fft.h
@@ -2,7 +2,6 @@
 
 #include <dsplib/math.h>
 #include <dsplib/fft.h>
-#include <dsplib/math.h>
 
 #include <memory>
 
@@ -15,14 +14,14 @@ class FactorFFTPlan : public FftPlanC
 {
 public:
     explicit FactorFFTPlan(int n);
-    ~FactorFFTPlan() = default;
+    ~FactorFFTPlan() override = default;
     [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
+    void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:
-    int _n;
-    arr_cmplx _twiddle;
-    mutable arr_cmplx _px;   ///< tmp matrix for transpose
+    const int _n;
+    const arr_cmplx _twiddle;
     std::shared_ptr<PlanTree> _plan;
 };
 

--- a/lib/fft/fact-fft.h
+++ b/lib/fft/fact-fft.h
@@ -15,6 +15,7 @@ class FactorFFTPlan : public FftPlanC
 public:
     explicit FactorFFTPlan(int n);
     ~FactorFFTPlan() override = default;
+
     [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
     void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const final;
     [[nodiscard]] int size() const noexcept final;
@@ -32,11 +33,15 @@ public:
       : _plan{n} {
     }
 
-    ~FactorFFTPlanR() = default;
+    ~FactorFFTPlanR() override = default;
 
     [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final {
         //TODO: real optimization (for odd sizes)
         return _plan.solve(complex(x));
+    }
+
+    void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const final {
+        _plan.solve(complex(x), r);
     }
 
     [[nodiscard]] int size() const noexcept final {

--- a/lib/fft/pow2-fft.cpp
+++ b/lib/fft/pow2-fft.cpp
@@ -65,10 +65,10 @@ void _bitreverse(const cmplx_t* restrict x, cmplx_t* restrict y, const int32_t* 
 
 Pow2FftPlan::Pow2FftPlan(int n)
   : n_{n}
-  , l_{nextpow2(n_)} {
+  , l_{nextpow2(n_)}
+  , bitrev_{_gen_bitrev_table(n)}
+  , coeffs_{_gen_coeffs_table(n)} {
     DSPLIB_ASSERT(ispow2(n), "FFT size must be power of 2");
-    bitrev_ = _gen_bitrev_table(n);
-    coeffs_ = _gen_coeffs_table(n);
 }
 
 void Pow2FftPlan::solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const {

--- a/lib/fft/pow2-fft.cpp
+++ b/lib/fft/pow2-fft.cpp
@@ -71,10 +71,16 @@ Pow2FftPlan::Pow2FftPlan(int n)
     coeffs_ = _gen_coeffs_table(n);
 }
 
+void Pow2FftPlan::solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const {
+    DSPLIB_ASSERT(x.size() == n_, "array size error");
+    DSPLIB_ASSERT(r.size() == n_, "array size error");
+    _fft(x.data(), r.data(), n_);
+}
+
 arr_cmplx Pow2FftPlan::solve(span_t<cmplx_t> x) const {
-    arr_cmplx y(x.size());
-    _fft(x.data(), y.data(), n_);
-    return y;
+    arr_cmplx r(x.size());
+    this->solve(x, r);
+    return r;
 }
 
 int Pow2FftPlan::size() const noexcept {

--- a/lib/fft/pow2-fft.cpp
+++ b/lib/fft/pow2-fft.cpp
@@ -73,13 +73,8 @@ Pow2FftPlan::Pow2FftPlan(int n)
 
 arr_cmplx Pow2FftPlan::solve(span_t<cmplx_t> x) const {
     arr_cmplx y(x.size());
-    this->solve(x, y);
+    _fft(x.data(), y.data(), n_);
     return y;
-}
-
-void Pow2FftPlan::solve(const cmplx_t* x, cmplx_t* y, int n) const {
-    DSPLIB_ASSERT(x != y, "Pointers must be restricted");
-    _fft(x, y, n);
 }
 
 int Pow2FftPlan::size() const noexcept {

--- a/lib/fft/pow2-fft.cpp
+++ b/lib/fft/pow2-fft.cpp
@@ -71,10 +71,9 @@ Pow2FftPlan::Pow2FftPlan(int n)
     coeffs_ = _gen_coeffs_table(n);
 }
 
-arr_cmplx Pow2FftPlan::solve(const arr_cmplx& x) const {
-    const int n = x.size();
-    arr_cmplx y(n);
-    solve(x.data(), y.data(), n);
+arr_cmplx Pow2FftPlan::solve(span_t<cmplx_t> x) const {
+    arr_cmplx y(x.size());
+    this->solve(x, y);
     return y;
 }
 

--- a/lib/fft/pow2-fft.h
+++ b/lib/fft/pow2-fft.h
@@ -11,6 +11,7 @@ class Pow2FftPlan : public FftPlanC
 public:
     explicit Pow2FftPlan(int n);
     [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
+    void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fft/pow2-fft.h
+++ b/lib/fft/pow2-fft.h
@@ -11,9 +11,9 @@ class Pow2FftPlan : public FftPlanC
 public:
     explicit Pow2FftPlan(int n);
 
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final;
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
 
-    void solve(const cmplx_t* x, cmplx_t* y, int n) const final;
+    void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> y) const final;
 
     [[nodiscard]] int size() const noexcept final;
 

--- a/lib/fft/pow2-fft.h
+++ b/lib/fft/pow2-fft.h
@@ -19,8 +19,8 @@ private:
 
     const int n_;
     const int l_;
-    std::vector<int32_t> bitrev_;
-    std::vector<cmplx_t> coeffs_;
+    const std::vector<int32_t> bitrev_;
+    const std::vector<cmplx_t> coeffs_;
 };
 
 }   // namespace dsplib

--- a/lib/fft/pow2-fft.h
+++ b/lib/fft/pow2-fft.h
@@ -10,11 +10,7 @@ class Pow2FftPlan : public FftPlanC
 {
 public:
     explicit Pow2FftPlan(int n);
-
     [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
-
-    void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> y) const final;
-
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -72,14 +72,14 @@ private:
         DSPLIB_ASSUME(n == n_);
 
         if (n <= MAX_DFT_SIZE) {
-            DSPLIB_ASSUME(!w_.empty());
+            assert(!w_.empty());
             _dft_slow(x, y, n, w_.data());
             return;
         }
 
         if (n > MAX_DFT_SIZE) {
             //TODO: noexcept?
-            DSPLIB_ASSUME(czt_ && czt_->size() == n);
+            assert(czt_ && czt_->size() == n);
             czt_->solve(span(x, n), span(y, n));
         }
     }

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -3,6 +3,8 @@
 #include "dsplib/czt.h"
 #include "dsplib/fft.h"
 #include "dsplib/math.h"
+#include "dsplib/span.h"
+#include "dsplib/utils.h"
 
 #include <cassert>
 #include <cstring>
@@ -28,7 +30,7 @@ public:
         }
     }
 
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final {
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final {
         arr_cmplx y(x.size());
         _dft(x.data(), y.data(), y.size());
         return y;
@@ -36,11 +38,6 @@ public:
 
     [[nodiscard]] int size() const noexcept final {
         return n_;
-    }
-
-    void solve(const cmplx_t* restrict x, cmplx_t* restrict y, int n) const final {
-        DSPLIB_ASSERT(x != y, "Pointers must be restricted");
-        _dft(x, y, n);
     }
 
 private:
@@ -78,7 +75,7 @@ private:
             //TODO: noexcept?
             //TODO: call without copy
             assert(czt_ && czt_->size() == n);
-            const auto r = czt_->solve(complex(x, n));
+            const auto r = czt_->solve(span(x, n));
             std::memcpy(y, r.data(), n * sizeof(cmplx_t));
         }
     }

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -102,6 +102,10 @@ public:
         return plan_.solve(complex(x));
     }
 
+    void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const final {
+        plan_.solve(complex(x), r);
+    }
+
     [[nodiscard]] int size() const noexcept final {
         return plan_.size();
     }

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -3,7 +3,6 @@
 #include "dsplib/czt.h"
 #include "dsplib/fft.h"
 #include "dsplib/math.h"
-#include "dsplib/utils.h"
 
 #include <cassert>
 #include <cstring>
@@ -79,7 +78,7 @@ private:
             //TODO: noexcept?
             //TODO: call without copy
             assert(czt_ && czt_->size() == n);
-            const auto r = czt_->solve(arr_cmplx(x, n));
+            const auto r = czt_->solve(complex(x, n));
             std::memcpy(y, r.data(), n * sizeof(cmplx_t));
         }
     }
@@ -98,7 +97,7 @@ public:
       : plan_{n} {
     }
 
-    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
+    [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final {
         return plan_.solve(complex(x));
     }
 

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -80,7 +80,7 @@ private:
         if (n > MAX_DFT_SIZE) {
             //TODO: noexcept?
             assert(czt_ && czt_->size() == n);
-            czt_->solve(span(x, n), span(y, n));
+            czt_->solve(make_span(x, n), make_span(y, n));
         }
     }
 

--- a/lib/fft/real-fft.cpp
+++ b/lib/fft/real-fft.cpp
@@ -14,39 +14,43 @@ RealFftPlan::RealFftPlan(int n)
 }
 
 arr_cmplx RealFftPlan::solve(span_t<real_t> x) const {
+    arr_cmplx r(n_);
+    this->solve(x, r);
+    return r;
+}
+
+void RealFftPlan::solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const {
     using namespace std::complex_literals;
     DSPLIB_ASSERT(x.size() == n_, "Input size must be equal FFT size");
+    //TODO: n/2+1 size support
+    DSPLIB_ASSERT(r.size() == n_, "Output size must be equal FFT size");
     const int n2 = n_ / 2;
 
     arr_cmplx z(span(reinterpret_cast<const cmplx_t*>(x.data()), n2));
     const auto Z = fft_->solve(z * 0.5);
 
-    arr_cmplx res(n_);
-
     {
         const auto Xe = Z[0] + conj(Z[0]);
         const auto Xo = (conj(Z[0]) - Z[0]) * w_[0];
-        res[0].re = Xe.re - Xo.im;
-        res[0].im = Xe.im + Xo.re;
+        r[0].re = Xe.re - Xo.im;
+        r[0].im = Xe.im + Xo.re;
     }
 
     for (int i = 1; i < n2; ++i) {
         const auto Zc = conj(Z[n2 - i]);
         const auto Xe = Z[i] + Zc;
         const auto Xo = (Zc - Z[i]) * w_[i];
-        res[i].re = Xe.re - Xo.im;
-        res[i].im = Xe.im + Xo.re;
-        res[n_ - i].re = res[i].re;
-        res[n_ - i].im = -res[i].im;
+        r[i].re = Xe.re - Xo.im;
+        r[i].im = Xe.im + Xo.re;
+        r[n_ - i].re = r[i].re;
+        r[n_ - i].im = -r[i].im;
     }
 
     {
         const auto Xe = Z[0] + conj(Z[0]);
         const auto Xo = conj(Z[0]) - Z[0];
-        res[n2] = Xe.re + Xo.im;
+        r[n2] = Xe.re + Xo.im;
     }
-
-    return res;
 }
 
 int RealFftPlan::size() const noexcept {

--- a/lib/fft/real-fft.cpp
+++ b/lib/fft/real-fft.cpp
@@ -13,12 +13,12 @@ RealFftPlan::RealFftPlan(int n)
     DSPLIB_ASSERT(n % 2 == 0, "FFT size must be even");
 }
 
-arr_cmplx RealFftPlan::solve(const arr_real& x) const {
+arr_cmplx RealFftPlan::solve(span_t<real_t> x) const {
     using namespace std::complex_literals;
     DSPLIB_ASSERT(x.size() == n_, "Input size must be equal FFT size");
     const int n2 = n_ / 2;
 
-    arr_cmplx z(reinterpret_cast<const cmplx_t*>(x.data()), n2);
+    arr_cmplx z(span(reinterpret_cast<const cmplx_t*>(x.data()), n2));
     const auto Z = fft_->solve(z * 0.5);
 
     arr_cmplx res(n_);

--- a/lib/fft/real-fft.cpp
+++ b/lib/fft/real-fft.cpp
@@ -26,7 +26,7 @@ void RealFftPlan::solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const {
     DSPLIB_ASSERT(r.size() == n_, "Output size must be equal FFT size");
     const int n2 = n_ / 2;
 
-    arr_cmplx z(span(reinterpret_cast<const cmplx_t*>(x.data()), n2));
+    arr_cmplx z(make_span(reinterpret_cast<const cmplx_t*>(x.data()), n2));
     const auto Z = fft_->solve(z * 0.5);
 
     {

--- a/lib/fft/real-fft.h
+++ b/lib/fft/real-fft.h
@@ -9,6 +9,7 @@ class RealFftPlan : public FftPlanR
 public:
     explicit RealFftPlan(int n);
     [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final;
+    void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fft/real-fft.h
+++ b/lib/fft/real-fft.h
@@ -8,7 +8,7 @@ class RealFftPlan : public FftPlanR
 {
 public:
     explicit RealFftPlan(int n);
-    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final;
+    [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fft/real-ifft.cpp
+++ b/lib/fft/real-ifft.cpp
@@ -31,7 +31,7 @@ RealIfftPlan::RealIfftPlan(int n)
     DSPLIB_ASSERT(n % 2 == 0, "ifft size must be even");
 }
 
-arr_real RealIfftPlan::solve(const arr_cmplx& x) const {
+arr_real RealIfftPlan::solve(span_t<cmplx_t> x) const {
     assert(n_ % 2 == 0);
     DSPLIB_ASSERT((x.size() == n_) || (x.size() == n_ / 2 + 1), "input size must be n/2+1 or n");
 

--- a/lib/fft/real-ifft.cpp
+++ b/lib/fft/real-ifft.cpp
@@ -32,8 +32,15 @@ RealIfftPlan::RealIfftPlan(int n)
 }
 
 arr_real RealIfftPlan::solve(span_t<cmplx_t> x) const {
+    arr_real r(n_);
+    this->solve(x, r);
+    return r;
+}
+
+void RealIfftPlan::solve(span_t<cmplx_t> x, mut_span_t<real_t> r) const {
     assert(n_ % 2 == 0);
     DSPLIB_ASSERT((x.size() == n_) || (x.size() == n_ / 2 + 1), "input size must be n/2+1 or n");
+    DSPLIB_ASSERT(r.size() == n_, "output size must be n");
 
     const real_t dn = real_t(1) / n_;
     std::vector<cmplx_t> Z(n_ / 2);
@@ -46,12 +53,10 @@ arr_real RealIfftPlan::solve(span_t<cmplx_t> x) const {
     }
 
     const auto z = fft_->solve(Z);
-    std::vector<real_t> r(n_);
     for (int i = 0; i < n_ / 2; ++i) {
         r[2 * i] = z[i].re;
         r[2 * i + 1] = -z[i].im;
     }
-    return r;
 }
 
 int RealIfftPlan::size() const noexcept {

--- a/lib/fft/real-ifft.h
+++ b/lib/fft/real-ifft.h
@@ -9,7 +9,7 @@ class RealIfftPlan : public IfftPlanR
 {
 public:
     explicit RealIfftPlan(int n);
-    [[nodiscard]] arr_real solve(const arr_cmplx& x) const final;
+    [[nodiscard]] arr_real solve(span_t<cmplx_t>) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fft/real-ifft.h
+++ b/lib/fft/real-ifft.h
@@ -10,6 +10,7 @@ class RealIfftPlan : public IfftPlanR
 public:
     explicit RealIfftPlan(int n);
     [[nodiscard]] arr_real solve(span_t<cmplx_t>) const final;
+    void solve(span_t<cmplx_t> x, mut_span_t<real_t> r) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fft/small-fft.h
+++ b/lib/fft/small-fft.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "dsplib/array.h"
-#include "dsplib/types.h"
 #include <dsplib/fft.h>
 #include <dsplib/assert.h>
 
@@ -22,30 +20,35 @@ public:
     ~SmallFftC() override {
     }
 
-    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final {
+    void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const final {
         DSPLIB_ASSERT(x.size() == n_, "input size error");
-        arr_cmplx y(x.size());
+        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
         switch (n_) {
         case 1:
-            y[0] = x[0];
+            r[0] = x[0];
             break;
         case 2:
-            _fft_n2(x.data(), y.data());
+            _fft_n2(x.data(), r.data());
             break;
         case 3:
-            _fft_n3(x.data(), y.data());
+            _fft_n3(x.data(), r.data());
             break;
         case 4:
-            _fft_n4(x.data(), y.data());
+            _fft_n4(x.data(), r.data());
             break;
         case 8:
-            _fft_n8(x.data(), y.data());
+            _fft_n8(x.data(), r.data());
             break;
         default:
             DSPLIB_THROW("size not supported");
             break;
         }
-        return y;
+    }
+
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final {
+        arr_cmplx r(x.size());
+        this->solve(x, r);
+        return r;
     }
 
     [[nodiscard]] int size() const noexcept final {
@@ -137,30 +140,36 @@ public:
     ~SmallFftR() override {
     }
 
-    [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final {
+    void solve(span_t<real_t> x, mut_span_t<cmplx_t> r) const final {
         DSPLIB_ASSERT(x.size() == n_, "input size error");
-        arr_cmplx y(x.size());
+        DSPLIB_ASSERT(x.size() == r.size(), "input size error");
         switch (n_) {
         case 1:
-            y[0] = x[0];
+            r[0].re = x[0];
+            r[0].im = 0;
             break;
         case 2:
-            _fft_n2(x.data(), y.data());
+            _fft_n2(x.data(), r.data());
             break;
         case 3:
-            _fft_n3(x.data(), y.data());
+            _fft_n3(x.data(), r.data());
             break;
         case 4:
-            _fft_n4(x.data(), y.data());
+            _fft_n4(x.data(), r.data());
             break;
         case 8:
-            _fft_n8(x.data(), y.data());
+            _fft_n8(x.data(), r.data());
             break;
         default:
             DSPLIB_THROW("size not supported");
             break;
         }
-        return y;
+    }
+
+    [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final {
+        arr_cmplx r(x.size());
+        this->solve(x, r);
+        return r;
     }
 
     [[nodiscard]] int size() const noexcept final {

--- a/lib/fft/small-fft.h
+++ b/lib/fft/small-fft.h
@@ -22,33 +22,29 @@ public:
     ~SmallFftC() override {
     }
 
-    void solve(const cmplx_t* x, cmplx_t* y, int n) const final {
-        DSPLIB_ASSERT(n == n_, "input size error");
+    [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final {
+        DSPLIB_ASSERT(x.size() == n_, "input size error");
+        arr_cmplx y(x.size());
         switch (n_) {
         case 1:
             y[0] = x[0];
             break;
         case 2:
-            _fft_n2(x, y);
+            _fft_n2(x.data(), y.data());
             break;
         case 3:
-            _fft_n3(x, y);
+            _fft_n3(x.data(), y.data());
             break;
         case 4:
-            _fft_n4(x, y);
+            _fft_n4(x.data(), y.data());
             break;
         case 8:
-            _fft_n8(x, y);
+            _fft_n8(x.data(), y.data());
             break;
         default:
             DSPLIB_THROW("size not supported");
             break;
         }
-    }
-
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final {
-        arr_cmplx y(x.size());
-        solve(x.data(), y.data(), x.size());
         return y;
     }
 
@@ -141,33 +137,29 @@ public:
     ~SmallFftR() override {
     }
 
-    void solve(const real_t* x, cmplx_t* y, int n) const final {
-        DSPLIB_ASSERT(n == n_, "input size error");
+    [[nodiscard]] arr_cmplx solve(span_t<real_t> x) const final {
+        DSPLIB_ASSERT(x.size() == n_, "input size error");
+        arr_cmplx y(x.size());
         switch (n_) {
         case 1:
             y[0] = x[0];
             break;
         case 2:
-            _fft_n2(x, y);
+            _fft_n2(x.data(), y.data());
             break;
         case 3:
-            _fft_n3(x, y);
+            _fft_n3(x.data(), y.data());
             break;
         case 4:
-            _fft_n4(x, y);
+            _fft_n4(x.data(), y.data());
             break;
         case 8:
-            _fft_n8(x, y);
+            _fft_n8(x.data(), y.data());
             break;
         default:
             DSPLIB_THROW("size not supported");
             break;
         }
-    }
-
-    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
-        arr_cmplx y(x.size());
-        solve(x.data(), y.data(), x.size());
         return y;
     }
 

--- a/lib/fir.cpp
+++ b/lib/fir.cpp
@@ -88,9 +88,7 @@ arr_real FftFilter::process(const arr_real& x) {
 
 //----------------------------------------------------------------------------------------------
 static arr_real _lowpass_fir(int n, real_t wn, const arr_real& win) {
-    if (win.size() != (n + 1)) {
-        DSPLIB_THROW("Window must be n+1 elements");
-    }
+    DSPLIB_ASSERT(win.size() == (n + 1), "Window must be n+1 elements");
 
     const bool is_odd = (n % 2 == 1);
     const int M = win.size();
@@ -184,18 +182,14 @@ arr_real fir1(int n, real_t wn1, real_t wn2, FilterType ftype, const arr_real& w
 }
 
 arr_real fir1(int n, real_t wn, FilterType ftype) {
-    if ((ftype != FilterType::High) && (ftype != FilterType::Low)) {
-        DSPLIB_THROW("Not supported for current filter type");
-    }
-
+    DSPLIB_ASSERT((ftype == FilterType::High) || (ftype == FilterType::Low), "Not supported for current filter type");
     const int nn = ((n % 2 == 1) && (ftype == FilterType::High)) ? (n + 2) : (n + 1);
     return fir1(n, wn, ftype, window::hamming(nn));
 }
 
 arr_real fir1(int n, real_t wn1, real_t wn2, FilterType ftype) {
-    if ((ftype != FilterType::Bandstop) && (ftype != FilterType::Bandpass)) {
-        DSPLIB_THROW("Not supported for current filter type");
-    }
+    DSPLIB_ASSERT((ftype == FilterType::Bandstop) || (ftype == FilterType::Bandpass),
+                  "Not supported for current filter type");
     const int nn = ((n % 2 == 1) && (ftype == FilterType::Bandstop)) ? (n + 2) : (n + 1);
     return fir1(n, wn1, wn2, ftype, window::hamming(nn));
 }

--- a/lib/fir.cpp
+++ b/lib/fir.cpp
@@ -102,7 +102,7 @@ static arr_real _lowpass_fir(int n, real_t wn, const arr_real& win) {
     auto h = zeros(M);
     h.slice(0, L) = sin(2 * pi * fc * tt) / tt * w;
     if (!is_odd) {
-        h(L) = 2 * pi * fc;
+        h[L] = 2 * pi * fc;
         h.slice(L + 1, M) = flip(h.slice(0, L));
     } else {
         h.slice(L, M) = flip(h.slice(0, L));
@@ -146,7 +146,7 @@ static arr_real _bandstop_fir(int n, real_t wn1, real_t wn2, const arr_real& win
     }
 
     auto h = (-1) * _bandpass_fir(n, wn1, wn2, win);
-    h(n / 2) = h(n / 2) + 1;
+    h[n / 2] = h[n / 2] + 1;
     return h;
 }
 

--- a/lib/hilbert.cpp
+++ b/lib/hilbert.cpp
@@ -29,13 +29,13 @@ arr_cmplx HilbertFilter::design_fir(int flen, real_t fs, real_t f1) {
 
     const auto lm = power(arange(k1 - 1) / (k1 - 1), 8);
     const auto rm = flip(lm);
-    const arr_cmplx H = complex(lm | ones(k2 - k1 + 1) | rm | zeros(N / 2 - 1));
+    const arr_cmplx H = complex(concatenate(lm, ones(k2 - k1 + 1), rm, zeros(N / 2 - 1)));
     const arr_cmplx h = ifft(H);   // desired impulse response
 
     const auto w = window::kaiser(M, 8);
-    const auto wzp = *w.slice(M / 2, M) | zeros(N - M) | *w.slice(0, M / 2);
+    const auto wzp = concatenate(w.slice(M / 2, M), zeros(N - M), w.slice(0, M / 2));
     const auto hw = wzp * h;   // single-sideband FIR filter, zero-centered
-    const auto hh = *hw.slice(N - (M / 2), N) | *hw.slice(0, (M + 1) / 2);   // casual FIR
+    const auto hh = concatenate(hw.slice(N - (M / 2), N), hw.slice(0, (M + 1) / 2));   // casual FIR
     return hh;
 }
 

--- a/lib/ifft.cpp
+++ b/lib/ifft.cpp
@@ -5,16 +5,16 @@
 namespace dsplib {
 
 //---------------------------------------------------------------------------------
-arr_cmplx ifft(const arr_cmplx& x) {
+arr_cmplx ifft(span_t<cmplx_t> x) {
     auto plan = ifft_plan_c(x.size());
     return plan->solve(x);
 }
 
-arr_real irfft(const arr_cmplx& x) {
+arr_real irfft(span_t<cmplx_t> x) {
     return irfft(x, x.size());
 }
 
-arr_real irfft(const arr_cmplx& x, int n) {
+arr_real irfft(span_t<cmplx_t> x, int n) {
     auto plan = ifft_plan_r(n);
     return plan->solve(x);
 }

--- a/lib/math.cpp
+++ b/lib/math.cpp
@@ -260,7 +260,7 @@ real_t imag(const cmplx_t& x) {
 }
 
 //-------------------------------------------------------------------------------------------------
-arr_cmplx complex(const arr_real& re, const arr_real& im) {
+arr_cmplx complex(span_real re, span_real im) {
     DSPLIB_ASSERT(re.size() == im.size(), "array sizes are different");
     const int n = re.size();
     arr_cmplx r(n);
@@ -271,8 +271,12 @@ arr_cmplx complex(const arr_real& re, const arr_real& im) {
     return r;
 }
 
-arr_cmplx complex(const arr_real& re) noexcept {
-    return array_cast<cmplx_t>(re);
+arr_cmplx complex(span_real re) {
+    arr_cmplx r(re.size());
+    for (int i = 0; i < re.size(); ++i) {
+        r[i].re = re[i];
+    }
+    return r;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/lib/math.cpp
+++ b/lib/math.cpp
@@ -14,29 +14,29 @@
 namespace dsplib {
 
 //-------------------------------------------------------------------------------------------------
-real_t max(const arr_real& arr) {
+real_t max(span_real arr) {
     return *std::max_element(arr.begin(), arr.end());
 }
 
-cmplx_t max(const arr_cmplx& arr) {
+cmplx_t max(span_cmplx arr) {
     return *std::max_element(arr.begin(), arr.end());
 }
 
 //-------------------------------------------------------------------------------------------------
-int argmax(const arr_real& arr) {
+int argmax(span_real arr) {
     return std::distance(arr.begin(), std::max_element(arr.begin(), arr.end()));
 }
 
-int argmax(const arr_cmplx& arr) {
+int argmax(span_cmplx arr) {
     return std::distance(arr.begin(), std::max_element(arr.begin(), arr.end()));
 }
 
 //-------------------------------------------------------------------------------------------------
-real_t min(const arr_real& arr) {
+real_t min(span_real arr) {
     return *std::min_element(arr.begin(), arr.end());
 }
 
-cmplx_t min(const arr_cmplx& arr) {
+cmplx_t min(span_cmplx arr) {
     return *std::min_element(arr.begin(), arr.end());
 }
 
@@ -52,11 +52,11 @@ cmplx_t peak2peak(const arr_cmplx& arr) {
 }
 
 //-------------------------------------------------------------------------------------------------
-int argmin(const arr_real& arr) {
+int argmin(span_real arr) {
     return std::distance(arr.begin(), std::min_element(arr.begin(), arr.end()));
 }
 
-int argmin(const arr_cmplx& arr) {
+int argmin(span_cmplx arr) {
     return std::distance(arr.begin(), std::min_element(arr.begin(), arr.end()));
 }
 
@@ -261,9 +261,10 @@ real_t imag(const cmplx_t& x) {
 
 //-------------------------------------------------------------------------------------------------
 arr_cmplx complex(const arr_real& re, const arr_real& im) {
-    DSPLIB_ASSERT(re.size() == im.size(), "arrays sizes must be equal");
-    arr_cmplx r(re.size());
-    for (int i = 0; i < r.size(); ++i) {
+    DSPLIB_ASSERT(re.size() == im.size(), "array sizes are different");
+    const int n = re.size();
+    arr_cmplx r(n);
+    for (int i = 0; i < n; ++i) {
         r[i].re = re[i];
         r[i].im = im[i];
     }

--- a/lib/medfilt.cpp
+++ b/lib/medfilt.cpp
@@ -68,7 +68,7 @@ arr_real medfilt(arr_real& x, int n) {
     auto flt = MedianFilter(n);
     const int n1 = (n / 2);
     const int n2 = (n % 2 == 1) ? (n / 2) : (n / 2 - 1);
-    arr_real xp = zeros(n1) | x | zeros(n2);
+    arr_real xp = concatenate(zeros(n1), x, zeros(n2));
     auto y = flt.process(xp);
     return y.slice(n - 1, indexing::end);
 }

--- a/lib/medfilt.cpp
+++ b/lib/medfilt.cpp
@@ -41,9 +41,7 @@ static void _update_sort(real_t* x, int nx, real_t v_new, real_t v_old) {
 MedianFilter::MedianFilter(int n, real_t init_value)
   : _i{0}
   , _n{n} {
-    if (n < 3) {
-        DSPLIB_THROW("The filter order must be greater than or equal to 3")
-    }
+    DSPLIB_ASSERT(n >= 3, "The filter order must be greater than or equal to 3");
     _d = zeros(_n);
     _s = zeros(_n);
     std::fill(_d.begin(), _d.end(), init_value);

--- a/lib/subband.cpp
+++ b/lib/subband.cpp
@@ -182,11 +182,12 @@ public:
             const auto* restrict buf = buf_[decim_ * k];
             const auto* restrict flt = fview_[k];
             for (int m = 0; m < nbands_; m++) {
-                pout[nbands_ - m - 1] += flt[m] * buf[m];
+                pout[m] += flt[m] * buf[m];
             }
         }
 
-        return fft_->solve(pout);
+        //TODO: remove conj
+        return conj(fft_->solve(pout));
     }
 
 private:
@@ -212,6 +213,8 @@ public:
 
         auto xx = ifft_->solve(x);
         xx *= nbands_;
+
+        //TODO: fft and flip?
         buf_.push(xx, true);
 
         // calculate outputs of polyphase filters

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -290,4 +290,24 @@ arr_cmplx zadoff_chu(int r, int n) {
     return expj(arg);
 }
 
+arr_real zeropad(span_t<real_t> x, int n) {
+    DSPLIB_ASSERT(x.size() <= n, "padding size error");
+    if (x.size() == n) {
+        return x;
+    }
+    arr_real r(n);
+    r.slice(0, x.size()) = x;
+    return r;
+}
+
+arr_cmplx zeropad(span_t<cmplx_t> x, int n) {
+    DSPLIB_ASSERT(x.size() <= n, "padding size error");
+    if (x.size() == n) {
+        return x;
+    }
+    arr_cmplx r(n);
+    r.slice(0, x.size()) = x;
+    return r;
+}
+
 }   // namespace dsplib

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -200,11 +200,11 @@ static int _finddelay(const base_array<T>& x1, const base_array<T>& x2) {
     return -delay;
 }
 
-int finddelay(const dsplib::arr_real& x1, const dsplib::arr_real& x2) {
+int finddelay(const arr_real& x1, const arr_real& x2) {
     return _finddelay(x1, x2);
 }
 
-int finddelay(const dsplib::arr_cmplx& x1, const dsplib::arr_cmplx& x2) {
+int finddelay(const arr_cmplx& x1, const arr_cmplx& x2) {
     return _finddelay(x1, x2);
 }
 
@@ -290,24 +290,52 @@ arr_cmplx zadoff_chu(int r, int n) {
     return expj(arg);
 }
 
-arr_real zeropad(span_t<real_t> x, int n) {
+template<typename T>
+static base_array<T> _zeropad(span_t<T> x, int n) {
     DSPLIB_ASSERT(x.size() <= n, "padding size error");
     if (x.size() == n) {
         return x;
     }
-    arr_real r(n);
+    base_array<T> r(n);
     r.slice(0, x.size()) = x;
     return r;
 }
 
+arr_real zeropad(span_t<real_t> x, int n) {
+    return _zeropad<real_t>(x, n);
+}
+
 arr_cmplx zeropad(span_t<cmplx_t> x, int n) {
-    DSPLIB_ASSERT(x.size() <= n, "padding size error");
-    if (x.size() == n) {
-        return x;
+    return _zeropad<cmplx_t>(x, n);
+}
+
+template<class T>
+static base_array<T> _concatenate(span_t<T> a1, span_t<T> a2, span_t<T> a3, span_t<T> a4, span_t<T> a5) {
+    std::array<span_t<T>, 5> span_list{a1, a2, a3, a4, a5};
+
+    size_t nr = 0;
+    for (const auto& x : span_list) {
+        nr += x.size();
     }
-    arr_cmplx r(n);
-    r.slice(0, x.size()) = x;
+
+    base_array<T> r(nr);
+    auto* pr = r.data();
+    for (const auto& x : span_list) {
+        if (x.empty()) {
+            continue;
+        }
+        std::memcpy(pr, x.data(), x.size() * sizeof(T));
+        pr += x.size();
+    }
     return r;
+}
+
+arr_real concatenate(span_real x1, span_real x2, span_real x3, span_real x4, span_real x5) {
+    return _concatenate<real_t>(x1, x2, x3, x4, x5);
+}
+
+arr_cmplx concatenate(span_cmplx x1, span_cmplx x2, span_cmplx x3, span_cmplx x4, span_cmplx x5) {
+    return _concatenate<cmplx_t>(x1, x2, x3, x4, x5);
 }
 
 }   // namespace dsplib

--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -181,7 +181,7 @@ arr_real kaiser(int nw, real_t beta) {
         w[i] = std::abs(_besseli0(beta * std::sqrt(1 - (xi / xind))) / bes);
     }
     const arr_real wl = flip(*w.slice(odd, n));
-    return (wl | w);
+    return concatenate(wl, w);
 }
 
 }   // namespace dsplib::window

--- a/lib/xcorr.cpp
+++ b/lib/xcorr.cpp
@@ -27,6 +27,7 @@ arr_cmplx xcorr(const arr_cmplx& x1, const arr_cmplx& x2) {
 
 //-------------------------------------------------------------------------------------------------
 arr_real xcorr(const arr_real& x1, const arr_real& x2) {
+    //TODO: real fft optimization
     return real(xcorr(complex(x1), complex(x2)));
 }
 

--- a/tests/arr_cmpl_test.cpp
+++ b/tests/arr_cmpl_test.cpp
@@ -135,16 +135,6 @@ TEST(ArrCmplxTest, UnpackReal) {
 }
 
 //-------------------------------------------------------------------------------------------------
-TEST(ArrCmplxTest, UnpackCmplx) {
-    std::vector<short> s1 = {1, -2, -3, +4};
-    arr_cmplx a1 = to_complex(s1);
-    arr_cmplx a2 = {1 - 2i, -3 + 4i};
-    std::vector<short> s2 = from_complex<short>(a1);
-    ASSERT_EQ_ARR_REAL(s1, s2);
-    ASSERT_EQ_ARR_CMPLX(a1, a2);
-}
-
-//-------------------------------------------------------------------------------------------------
 TEST(ArrCmplxTest, UnpackStdComplex) {
     arr_cmplx r1 = {1.0i, -2.0i, -3.0i, +4.0i};
     std::vector<std::complex<float>> r2 = r1.to_vec<std::complex<float>>();

--- a/tests/arr_cmpl_test.cpp
+++ b/tests/arr_cmpl_test.cpp
@@ -129,7 +129,7 @@ TEST(ArrCmplxTest, Zeros) {
 //-------------------------------------------------------------------------------------------------
 TEST(ArrCmplxTest, UnpackReal) {
     std::vector<short> r1 = {1, -2, -3, +4};
-    arr_real s1(r1.data(), r1.size());
+    arr_real s1(span(r1.data(), r1.size()));
     std::vector<short> r2 = s1.to_vec<short>();
     ASSERT_EQ_ARR_REAL(r1, r2);
 }

--- a/tests/arr_cmpl_test.cpp
+++ b/tests/arr_cmpl_test.cpp
@@ -129,7 +129,7 @@ TEST(ArrCmplxTest, Zeros) {
 //-------------------------------------------------------------------------------------------------
 TEST(ArrCmplxTest, UnpackReal) {
     std::vector<short> r1 = {1, -2, -3, +4};
-    arr_real s1(span(r1.data(), r1.size()));
+    arr_real s1(make_span(r1.data(), r1.size()));
     std::vector<short> r2 = s1.to_vec<short>();
     ASSERT_EQ_ARR_REAL(r1, r2);
 }

--- a/tests/arr_real_test.cpp
+++ b/tests/arr_real_test.cpp
@@ -21,7 +21,7 @@ TEST(ArrRealTest, Init) {
     ASSERT_TRUE(a3.empty());
 
     std::vector<short> v1 = {-1, -2, 3, 4};
-    arr_real a8(span(v1.data(), v1.size()));
+    arr_real a8(make_span(v1.data(), v1.size()));
     ASSERT_EQ_ARR_REAL(v1, a8);
 
     std::vector<::real_t> v2 = {1, 2, 3, 4};

--- a/tests/arr_real_test.cpp
+++ b/tests/arr_real_test.cpp
@@ -21,7 +21,7 @@ TEST(ArrRealTest, Init) {
     ASSERT_TRUE(a3.empty());
 
     std::vector<short> v1 = {-1, -2, 3, 4};
-    arr_real a8{v1.data(), v1.size()};
+    arr_real a8{span(v1.data(), v1.size())};
     ASSERT_EQ_ARR_REAL(v1, a8);
 
     std::vector<::real_t> v2 = {1, 2, 3, 4};

--- a/tests/arr_real_test.cpp
+++ b/tests/arr_real_test.cpp
@@ -21,7 +21,7 @@ TEST(ArrRealTest, Init) {
     ASSERT_TRUE(a3.empty());
 
     std::vector<short> v1 = {-1, -2, 3, 4};
-    arr_real a8{span(v1.data(), v1.size())};
+    arr_real a8(span(v1.data(), v1.size()));
     ASSERT_EQ_ARR_REAL(v1, a8);
 
     std::vector<::real_t> v2 = {1, 2, 3, 4};

--- a/tests/fft_test.cpp
+++ b/tests/fft_test.cpp
@@ -98,7 +98,7 @@ TEST(FFT, FftCmplx) {
 
     {
         const int n = 128;
-        const auto x = complex(sin(2 * pi * arange(n) * 0.1));
+        const arr_cmplx x = complex(sin(2 * pi * arange(n) * 0.1));
         const arr_cmplx y = fft(x).slice(0, n / 2 + 1);
         ASSERT_EQ(argmax(y), 13);
         ASSERT_CMPLX_NEAR(max(y), cmplx_t{-34.4803383753629 - 48.7604203346960i});

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -244,6 +244,22 @@ TEST(MathTest, Abs2) {
 }
 
 //-------------------------------------------------------------------------------------------------
+TEST(MathTest, NextPow2) {
+    ASSERT_EQ(nextpow2(0), 0);
+    ASSERT_EQ(nextpow2(1), 0);
+    ASSERT_EQ(nextpow2(2), 1);
+    ASSERT_EQ(nextpow2(3), 2);
+    ASSERT_EQ(nextpow2(4), 2);
+    ASSERT_EQ(nextpow2(5), 3);
+    ASSERT_EQ(nextpow2(6), 3);
+    ASSERT_EQ(nextpow2(7), 3);
+    ASSERT_EQ(nextpow2(8), 3);
+    ASSERT_EQ(nextpow2(9), 4);
+    ASSERT_EQ(nextpow2(std::pow(2, 30)), 30);
+    ASSERT_EQ(nextpow2(std::pow(2, 30) + 1), 31);
+}
+
+//-------------------------------------------------------------------------------------------------
 TEST(MathTest, Deg2Rad) {
     arr_real deg = {0, 45, 90, 180, -45, -90, -180};
     arr_real rad = {0, pi / 4, pi / 2, pi, -pi / 4, -pi / 2, -pi};

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -329,10 +329,10 @@ TEST(MathTest, Pow2db) {
         ASSERT_EQ_ARR_REAL(mag2db(mag), db, 1e-3);
         ASSERT_EQ_ARR_REAL(pow2db(pow), db, 1e-3);
 
-        ASSERT_NEAR(db2pow(db(0)), pow(0), 1e-3);
-        ASSERT_NEAR(db2mag(db(0)), mag(0), 1e-3);
-        ASSERT_NEAR(mag2db(mag(0)), db(0), 1e-3);
-        ASSERT_NEAR(pow2db(pow(0)), db(0), 1e-3);
+        ASSERT_NEAR(db2pow(db[0]), pow[0], 1e-3);
+        ASSERT_NEAR(db2mag(db[0]), mag[0], 1e-3);
+        ASSERT_NEAR(mag2db(mag[0]), db[0], 1e-3);
+        ASSERT_NEAR(pow2db(pow[0]), db[0], 1e-3);
     }
 }
 

--- a/tests/span_test.cpp
+++ b/tests/span_test.cpp
@@ -36,6 +36,17 @@ TEST(SpanTest, ConstMutable) {
     }
 }
 
+TEST(SpanTest, NoTempValueUB) {
+    auto fn = [](span_real x) {
+        auto y = dsplib::fft(x);
+        return y;
+    };
+
+    auto y1 = fn(std::vector<real_t>{1, 2, 3, 4});
+    auto y2 = fft(arr_real(std::vector<real_t>{1, 2, 3, 4}));
+    ASSERT_EQ_ARR_CMPLX(y1, y2);
+}
+
 TEST(SpanTest, StdVector) {
     {
         std::vector<real_t> x = {-1, 1, 2, 3};

--- a/tests/span_test.cpp
+++ b/tests/span_test.cpp
@@ -1,0 +1,48 @@
+#include "tests_common.h"
+#include <gtest/gtest.h>
+
+using namespace dsplib;
+
+static real_t _first_span_elem(const span_real& x) {
+    return x[0];
+}
+
+TEST(SpanTest, Base) {
+    {
+        arr_real x1 = {-1, 2, -3, 4, -5};
+        x1.slice(0, 2) = 100;
+        ASSERT_EQ_ARR_REAL(x1, arr_real{100, 100, -3, 4, -5});
+    }
+}
+
+TEST(SpanTest, ConstMutable) {
+    {
+        arr_real x1 = {-1, 1, 2, 3};
+        auto span = x1.slice(0, indexing::end);
+        ASSERT_EQ(span.size(), 4);
+        arr_real x2(span);
+        ASSERT_EQ_ARR_REAL(x1, x2);
+        ASSERT_EQ(_first_span_elem(span), -1);
+        ASSERT_EQ(_first_span_elem(x1), -1);
+    }
+
+    {
+        arr_real x1 = {-1, 2, -3, 4, -5};
+        auto span = x1.slice(1, 3);
+        ASSERT_EQ(span.size(), 2);
+        arr_real x2(span);
+        ASSERT_EQ_ARR_REAL(x2, arr_real{2, -3});
+        ASSERT_EQ(_first_span_elem(span), 2);
+    }
+}
+
+TEST(SpanTest, StdVector) {
+    {
+        std::vector<real_t> x = {-1, 1, 2, 3};
+        ASSERT_EQ(dsplib::max(x), x[3]);
+    }
+    {
+        std::vector<cmplx_t> x = {-1i, 1i, 2i, 3i};
+        ASSERT_CMPLX_EQ(dsplib::max(x), x[3]);
+    }
+}

--- a/tests/span_test.cpp
+++ b/tests/span_test.cpp
@@ -57,3 +57,18 @@ TEST(SpanTest, StdVector) {
         ASSERT_CMPLX_EQ(dsplib::max(x), x[3]);
     }
 }
+
+TEST(SpanTest, RealToCmplx) {
+    {
+        arr_cmplx x = {1i, 2i, 3i, 4i};
+        x.slice(0, 2) = 1;
+        arr_cmplx y = {1, 1, 3i, 4i};
+        ASSERT_EQ_ARR_CMPLX(x, y);
+    }
+    {
+        arr_cmplx x = {1i, 2i, 3i, 4i};
+        x.slice(1, 3) = zeros(2);
+        arr_cmplx y = {1i, 0, 0, 4i};
+        ASSERT_EQ_ARR_CMPLX(x, y);
+    }
+}

--- a/tests/thread_safe_test.cpp
+++ b/tests/thread_safe_test.cpp
@@ -61,7 +61,7 @@ TEST(ThreadSafe, FftNonPow2) {
     int test_steps = 1000;
     while (--test_steps) {
         const int n = randi({100, 2000});
-        auto x1 = complex(dsplib::randn(n));
+        arr_cmplx x1 = complex(dsplib::randn(n));
         arr_cmplx x2 = x1;
 
         auto f1 = std::async([&]() {

--- a/tests/types_test.cpp
+++ b/tests/types_test.cpp
@@ -3,7 +3,6 @@
 
 using namespace dsplib;
 
-//-------------------------------------------------------------------------------------------------
 TEST(Template, CmplxScalarConvert) {
     //scalar -> cmplx_t
     ASSERT_TRUE(bool(std::is_convertible<double, cmplx_t>::value));
@@ -28,13 +27,11 @@ TEST(Template, CmplxScalarConvert) {
     ASSERT_FALSE(bool(std::is_convertible<cmplx_t, float>::value));
 }
 
-//-------------------------------------------------------------------------------------------------
 TEST(Template, IsScalar) {
     ASSERT_TRUE(bool(is_scalar_v<cmplx_t>));
     ASSERT_TRUE(bool(is_scalar_v<real_t>));
 }
 
-//-------------------------------------------------------------------------------------------------
 TEST(Template, ArrayConvert) {
     {
         ASSERT_TRUE(bool(is_array_convertible<float, real_t>()));
@@ -59,4 +56,12 @@ TEST(Template, ArrayConvert) {
 
     ASSERT_FALSE(bool(is_array_convertible<real_t, cmplx_t>()));
     ASSERT_FALSE(bool(is_array_convertible<cmplx_t, real_t>()));
+}
+
+TEST(Template, SupportTypeArray) {
+    ASSERT_TRUE(support_type_for_array<real_t>());
+    ASSERT_TRUE(support_type_for_array<cmplx_t>());
+    ASSERT_TRUE(support_type_for_array<int>());
+    ASSERT_FALSE(support_type_for_array<std::complex<float>>());
+    ASSERT_FALSE(support_type_for_array<std::complex<double>>());
 }

--- a/tests/types_test.cpp
+++ b/tests/types_test.cpp
@@ -37,24 +37,24 @@ TEST(Template, IsScalar) {
 //-------------------------------------------------------------------------------------------------
 TEST(Template, ArrayConvert) {
     {
-        ASSERT_TRUE(bool(is_array_convertible<float, double>()));
-        dsplib::base_array<float> x(dsplib::base_array<double>(10));
+        ASSERT_TRUE(bool(is_array_convertible<float, real_t>()));
+        dsplib::base_array<real_t> x(std::vector<float>(10));
     }
 
     {
-        ASSERT_TRUE(bool(is_array_convertible<double, float>()));
-        dsplib::base_array<double> x(dsplib::base_array<float>(10));
+        ASSERT_TRUE(bool(is_array_convertible<double, real_t>()));
+        dsplib::base_array<real_t> x(std::vector<double>(10));
     }
 
     {
-        ASSERT_FALSE(bool(is_array_convertible<float, int>()));
-        ASSERT_TRUE(bool(is_array_convertible<int, float>()));
-        dsplib::base_array<float> x(dsplib::base_array<int>(10));
+        ASSERT_FALSE(bool(is_array_convertible<real_t, int>()));
+        ASSERT_TRUE(bool(is_array_convertible<int, real_t>()));
+        dsplib::base_array<real_t> x(std::vector<int>(10));
     }
 
     {
         ASSERT_TRUE(bool(is_array_convertible<std::complex<real_t>, cmplx_t>()));
-        dsplib::base_array<cmplx_t> x(dsplib::base_array<std::complex<real_t>>(10));
+        dsplib::base_array<cmplx_t> x(std::vector<std::complex<real_t>>(10));
     }
 
     ASSERT_FALSE(bool(is_array_convertible<real_t, cmplx_t>()));

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -138,7 +138,7 @@ TEST(Utils, FromFile) {
         fwrite(s, sizeof(int16_t), 6, fid);
         fclose(fid);
 
-        auto x1 = arr_real(s, 6);
+        auto x1 = arr_real(span(s, 6));
         arr_real x2 = from_file("test.dat", dtype::int16, endian::little);
         ASSERT_EQ_ARR_REAL(x1, x2);
     }
@@ -150,7 +150,7 @@ TEST(Utils, FromFile) {
         fwrite(s, sizeof(uint16_t), 6, fid);
         fclose(fid);
 
-        auto x1 = arr_real(s + 1, 5);
+        auto x1 = arr_real(span(s + 1, 5));
         arr_real x2 = from_file("test.dat", dtype::uint16, endian::little, sizeof(uint16_t));
         ASSERT_EQ_ARR_REAL(x1, x2);
     }
@@ -162,7 +162,7 @@ TEST(Utils, FromFile) {
         fwrite(s, sizeof(int32_t), 6, fid);
         fclose(fid);
 
-        auto x1 = arr_real(s + 1, 3);
+        auto x1 = arr_real(span(s + 1, 3));
         arr_real x2 = from_file("test.dat", dtype::int32, endian::little, sizeof(int32_t), 3);
         ASSERT_EQ_ARR_REAL(x1, x2);
     }

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -138,7 +138,7 @@ TEST(Utils, FromFile) {
         fwrite(s, sizeof(int16_t), 6, fid);
         fclose(fid);
 
-        auto x1 = arr_real(span(s, 6));
+        auto x1 = arr_real(make_span(s, 6));
         arr_real x2 = from_file("test.dat", dtype::int16, endian::little);
         ASSERT_EQ_ARR_REAL(x1, x2);
     }
@@ -150,7 +150,7 @@ TEST(Utils, FromFile) {
         fwrite(s, sizeof(uint16_t), 6, fid);
         fclose(fid);
 
-        auto x1 = arr_real(span(s + 1, 5));
+        auto x1 = arr_real(make_span(s + 1, 5));
         arr_real x2 = from_file("test.dat", dtype::uint16, endian::little, sizeof(uint16_t));
         ASSERT_EQ_ARR_REAL(x1, x2);
     }
@@ -162,7 +162,7 @@ TEST(Utils, FromFile) {
         fwrite(s, sizeof(int32_t), 6, fid);
         fclose(fid);
 
-        auto x1 = arr_real(span(s + 1, 3));
+        auto x1 = arr_real(make_span(s + 1, 3));
         arr_real x2 = from_file("test.dat", dtype::int32, endian::little, sizeof(int32_t), 3);
         ASSERT_EQ_ARR_REAL(x1, x2);
     }


### PR DESCRIPTION
- Remove auto cast arr_real -> arr_cmplx;
- Add `complex(re)` function;
- Add `span` implementation;
- Return `span` from `slice` function for step=1;
- Remove `base_array` reference from `slice`;
- Check same array by pointer range;
- Simplify cast for `cmplx_t` type;
- Add `span` instead `base_array` for some `math` functions;
- Update tests;