### PR TITLE
Comparison operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(dsplib LANGUAGES CXX VERSION 0.45.6)
+project(dsplib LANGUAGES CXX VERSION 0.45.7)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -161,9 +161,8 @@ public:
     }
 
     //--------------------------------------------------------------------
-    template<typename T2>
-    std::vector<bool> operator>(T2 val) const noexcept {
-        static_assert(is_scalar_v<T2>, "Type is not scalar");
+    //compare scalar
+    std::vector<bool> operator>(T val) const noexcept {
         std::vector<bool> res(_vec.size());
         for (size_t i = 0; i < _vec.size(); ++i) {
             res[i] = (_vec[i] > val);
@@ -171,23 +170,57 @@ public:
         return res;
     }
 
-    template<typename T2>
-    std::vector<bool> operator<(T2 val) const noexcept {
-        auto r = (*this == val);
-        r.flip();
-        return r;
+    std::vector<bool> operator<(T val) const noexcept {
+        std::vector<bool> res(_vec.size());
+        for (size_t i = 0; i < _vec.size(); ++i) {
+            res[i] = (_vec[i] < val);
+        }
+        return res;
     }
 
     std::vector<bool> operator==(T val) const noexcept {
         std::vector<bool> res(_vec.size());
         for (size_t i = 0; i < _vec.size(); ++i) {
-            res[i] = std::fabs(_vec[i] - val) < eps(val);
+            //TODO: add tolerance for compare?
+            res[i] = (_vec[i] == val);
         }
         return res;
     }
 
     std::vector<bool> operator!=(T val) const noexcept {
         auto r = (*this == val);
+        r.flip();
+        return r;
+    }
+
+    //--------------------------------------------------------------------
+    //compare vector
+    std::vector<bool> operator>(const base_array<T>& rhs) const noexcept {
+        std::vector<bool> res(_vec.size());
+        for (size_t i = 0; i < _vec.size(); ++i) {
+            res[i] = (_vec[i] > rhs._vec[i]);
+        }
+        return res;
+    }
+
+    std::vector<bool> operator<(const base_array<T>& rhs) const noexcept {
+        std::vector<bool> res(_vec.size());
+        for (size_t i = 0; i < _vec.size(); ++i) {
+            res[i] = (_vec[i] < rhs._vec[i]);
+        }
+        return res;
+    }
+
+    std::vector<bool> operator==(const base_array<T>& rhs) const noexcept {
+        std::vector<bool> res(_vec.size());
+        for (size_t i = 0; i < _vec.size(); ++i) {
+            res[i] = (_vec[i] == rhs._vec[i]);
+        }
+        return res;
+    }
+
+    std::vector<bool> operator!=(const base_array<T>& rhs) const noexcept {
+        auto r = (*this == rhs);
         r.flip();
         return r;
     }

--- a/include/dsplib/types.h
+++ b/include/dsplib/types.h
@@ -219,6 +219,14 @@ struct cmplx_t
         return abs2() < rhs.abs2();
     }
 
+    constexpr bool operator==(const cmplx_t& rhs) const noexcept {
+        return (re == rhs.re) && (im == rhs.im);
+    }
+
+    constexpr bool operator!=(const cmplx_t& rhs) const noexcept {
+        return !(*this == rhs);
+    }
+
     [[nodiscard]] constexpr cmplx_t conj() const noexcept {
         return {re, -im};
     }

--- a/lib/fft/dft-tables.cpp
+++ b/lib/fft/dft-tables.cpp
@@ -51,7 +51,7 @@ std::vector<real_t> _gen_coeffs(const int n) {
 }   // namespace
 
 FftParam fft_tables(size_t size) {
-    thread_local static FftParam base_prm;
+    thread_local FftParam base_prm;
     if (base_prm.size < size) {
         DSPLIB_ASSERT(ispow2(size), "FFT table len must be power of 2");
         base_prm.coeffs = _gen_coeffs(size);

--- a/tests/arr_cmpl_test.cpp
+++ b/tests/arr_cmpl_test.cpp
@@ -194,3 +194,25 @@ TEST(ArrCmplxTest, Pow) {
         ASSERT_EQ_ARR_CMPLX(power(x1, x2), r);
     }
 }
+
+//-------------------------------------------------------------------------------------------------
+TEST(ArrCmplxTest, CompareOperator) {
+    const arr_cmplx x = {1i, 2i, 3i, 4i};
+    {
+        std::vector<bool> r = (x > 2i);
+        ASSERT_TRUE(bool(r == std::vector<bool>{false, false, true, true}));
+        ASSERT_EQ_ARR_CMPLX(x[r], arr_cmplx{3i, 4i});
+    }
+
+    {
+        std::vector<bool> r = (x < 2i);
+        ASSERT_TRUE(bool(r == std::vector<bool>{true, false, false, false}));
+        ASSERT_EQ_ARR_CMPLX(x[r], arr_cmplx{1i});
+    }
+
+    {
+        std::vector<bool> r = (x == 2i);
+        ASSERT_TRUE(bool(r == std::vector<bool>{false, true, false, false}));
+        ASSERT_EQ_ARR_CMPLX(x[r], arr_cmplx{2i});
+    }
+}

--- a/tests/arr_real_test.cpp
+++ b/tests/arr_real_test.cpp
@@ -132,12 +132,48 @@ TEST(ArrRealTest, CheckEqual) {
 }
 
 //-------------------------------------------------------------------------------------------------
-TEST(ArrRealTest, CheckGreater) {
-    arr_real x = {1.0, -1.0, 200, -1e-5, 10000.0};
-    std::vector<bool> r = (x > 1.0);
-    ASSERT_TRUE(bool(r == std::vector<bool>{false, false, true, false, true}));
-    auto y = x[r];
-    ASSERT_EQ_ARR_REAL(y, arr_real{200, 10000.0});
+TEST(ArrRealTest, CompareScalar) {
+    const arr_real x = {1.0, -1.0, 200, -1e-5, 10000.0};
+    {
+        std::vector<bool> r = (x > 1.0);
+        ASSERT_TRUE(bool(r == std::vector<bool>{false, false, true, false, true}));
+        ASSERT_EQ_ARR_REAL(x[r], arr_real{200, 10000.0});
+    }
+
+    {
+        std::vector<bool> r = (x < 1.0);
+        ASSERT_TRUE(bool(r == std::vector<bool>{false, true, false, true, false}));
+        ASSERT_EQ_ARR_REAL(x[r], arr_real{-1.0, -1e-5});
+    }
+
+    {
+        std::vector<bool> r = (abs(x) == 1.0);
+        ASSERT_TRUE(bool(r == std::vector<bool>{true, true, false, false, false}));
+        ASSERT_EQ_ARR_REAL(x[r], arr_real{1.0, -1.0});
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+TEST(ArrRealTest, CompareVector) {
+    const arr_real x = {1.0, -1.0, 200, 1e-5, 10000.0};
+    const arr_real y = {1.0, 2.0, 300, 1e-6, 10001.0};
+    {
+        std::vector<bool> r = (x > y);
+        ASSERT_TRUE(bool(r == std::vector<bool>{false, false, false, true, false}));
+        ASSERT_EQ_ARR_REAL(x[r], arr_real{1e-5});
+    }
+
+    {
+        std::vector<bool> r = (x < y);
+        ASSERT_TRUE(bool(r == std::vector<bool>{false, true, true, false, true}));
+        ASSERT_EQ_ARR_REAL(x[r], arr_real{-1.0, 200, 10000.0});
+    }
+
+    {
+        std::vector<bool> r = (x == y);
+        ASSERT_TRUE(bool(r == std::vector<bool>{true, false, false, false, false}));
+        ASSERT_EQ_ARR_REAL(x[r], arr_real{1.0});
+    }
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Fix error of scalar `operator<`;
- Add compare operators for vectors;
- Add compare operators for `cmplx_t` type;
- Remove `eps` from equal operators;
- Update tests;