### PR TITLE
Add `PrimesFft` class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(dsplib LANGUAGES CXX VERSION 0.45.7)
+project(dsplib LANGUAGES CXX VERSION 0.46.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/dsplib/czt.h
+++ b/include/dsplib/czt.h
@@ -30,6 +30,6 @@ private:
 * \param a Spiral contour initial point
 * \return Chirp Z-transform
 */
-arr_cmplx czt(arr_cmplx x, int m, cmplx_t w, cmplx_t a = 1);
+arr_cmplx czt(const arr_cmplx& x, int m, cmplx_t w, cmplx_t a = 1);
 
 }   // namespace dsplib

--- a/include/dsplib/fft.h
+++ b/include/dsplib/fft.h
@@ -11,6 +11,11 @@ class BaseFftPlanR
 public:
     virtual ~BaseFftPlanR() = default;
     [[nodiscard]] virtual arr_cmplx solve(const arr_real& x) const = 0;
+    virtual void solve(const real_t* x, cmplx_t* y, int n) const {
+        //TODO: use span
+        const auto r = this->solve(arr_real(x, n));
+        std::memcpy(y, r.data(), n * sizeof(cmplx_t));
+    }
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 
@@ -20,6 +25,10 @@ class BaseFftPlanC
 public:
     virtual ~BaseFftPlanC() = default;
     [[nodiscard]] virtual arr_cmplx solve(const arr_cmplx& x) const = 0;
+    virtual void solve(const cmplx_t* x, cmplx_t* y, int n) const {
+        const auto r = this->solve(arr_cmplx(x, n));
+        std::memcpy(y, r.data(), n * sizeof(cmplx_t));
+    }
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 

--- a/lib/fft/dft-tables.cpp
+++ b/lib/fft/dft-tables.cpp
@@ -1,4 +1,5 @@
-#include "dft-tables.h"
+#include "fft/dft-tables.h"
+
 #include <dsplib/throw.h>
 #include <dsplib/math.h>
 

--- a/lib/fft/dft-tables.h
+++ b/lib/fft/dft-tables.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <dsplib/types.h>
+
 #include <cstdint>
 #include <vector>
 

--- a/lib/fft/fact-fft.cpp
+++ b/lib/fft/fact-fft.cpp
@@ -1,5 +1,5 @@
-#include "fact-fft.h"
-#include "factory.h"
+#include "fft/fact-fft.h"
+#include "fft/factory.h"
 
 #include <dsplib/math.h>
 #include <dsplib/utils.h>

--- a/lib/fft/factory.h
+++ b/lib/fft/factory.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <dsplib/fft.h>
+
+namespace dsplib {
+
+//instance or get cached fft plan
+
+std::shared_ptr<BaseFftPlanC> create_fft_plan(int n);
+
+std::shared_ptr<BaseFftPlanR> create_rfft_plan(int n);
+
+}   // namespace dsplib

--- a/lib/fft/fft.cpp
+++ b/lib/fft/fft.cpp
@@ -2,13 +2,16 @@
 #include <dsplib/math.h>
 #include <dsplib/utils.h>
 
-#include "dft-tables.h"
+#include "fft/dft-tables.h"
+#include "fft/fact-fft.h"
+#include "fft/primes-fft.h"
+#include "fft/factory.h"
+#include "fft/pow2-fft.h"
+#include "fft/real-fft.h"
 #include "lru-cache.h"
-#include "fact-fft.h"
-#include "primes-fft.h"
-#include "factory.h"
 
 #include <cassert>
+#include <memory>
 
 namespace dsplib {
 
@@ -16,191 +19,25 @@ namespace {
 
 constexpr int FFT_CACHE_SIZE = DSPLIB_FFT_CACHE_SIZE;
 
-//-------------------------------------------------------------------------------------------------
-//cast cos table to complex for n==2^K
-arr_cmplx _cos_to_cmplx(const real_t* w, int n) {
-    assert(ispow2(n));
-    const int n4 = (n / 4);
-    const int ms = (n - 1);
-    arr_cmplx r(n);
-    for (int i = 0; i < n; ++i) {
-        r[i].re = w[i];
-        const int k = (i + n4) & ms;
-        r[i].im = w[k];
-    }
-    return r;
-}
+static_assert(FFT_CACHE_SIZE > 0);
 
-//-------------------------------------------------------------------------------------------------
-//bit reverse array permutation
-arr_cmplx _bitreverse(const arr_cmplx& x, const std::vector<int32_t>& bitrev) noexcept {
-    const size_t n = x.size();
-    const size_t n2 = n / 2;
-    assert(bitrev.size() == n2);
-    arr_cmplx r(n);
-    for (size_t i = 0; i < n2; ++i) {
-        const auto kl = bitrev[i];
-        const auto kr = kl + 1;
-        r[i] = x[kl];
-        r[n2 + i] = x[kr];
-    }
-    return r;
-}
-
-//-------------------------------------------------------------------------------------------------
-inline void _btrf(cmplx_t& x1, cmplx_t& x2, cmplx_t w) {
-    w *= x2;
-    x2 = x1 - w;
-    x1 = x1 + w;
-}
-
-//-------------------------------------------------------------------------------------------------
-arr_cmplx _fft_radix2(const arr_cmplx& in, const arr_cmplx& w, const std::vector<int32_t>& bitrev, int n) {
-    assert(n % 2 == 0);
-    assert(in.size() == n);
-    assert(w.size() == n);
-
-    //reverse sampling
-    auto x = _bitreverse(in, bitrev);
-
-    int h = 1;       ///< number of butterflies in clusters (and step between elements)
-    int m = n / 2;   ///< number of clusters (and step for the butterfly table)
-    int r = 2;       ///< number of elements (butterflies * 2) in clusters
-
-    cmplx_t* px;                 ///< pointer to go through the signal vector
-    const cmplx_t* pw;           ///< pointer to go through the coefficient vector
-    const int L = nextpow2(n);   ///< number of DFT runs
-
-    //cascades
-    for (int i = 0; i < L; ++i) {
-        px = x.data();
-        //clusters
-        for (int j = 0; j < m; ++j) {
-            pw = w.data();
-            //butterflies
-            for (int k = 0; k < h; ++k) {
-                _btrf(px[k], px[k + h], *pw);
-                pw += m;
-            }
-            px += r;
-        }
-
-        //next cascade
-        m /= 2;
-        h *= 2;
-        r *= 2;
-    }
-
-    return x;
-}
-
-//-------------------------------------------------------------------------------------------------
-class Fft2Plan : public BaseFftPlanC
-{
-public:
-    explicit Fft2Plan(int n)
-      : n_{n} {
-        const auto tb = fft_tables(n);
-        bitrev_ = tb.bitrev;
-        coeffs_ = _cos_to_cmplx(tb.coeffs.data(), tb.size);
-    }
-
-    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final {
-        return _fft_radix2(x, coeffs_, bitrev_, n_);
-    }
-
-    [[nodiscard]] int size() const noexcept final {
-        return n_;
-    }
-
-private:
-    const int n_;
-    std::vector<int32_t> bitrev_;
-    arr_cmplx coeffs_;
-};
-
-//-------------------------------------------------------------------------------------------------
 std::shared_ptr<BaseFftPlanC> _get_fft_plan(int n) {
-    //n!=2^K
     if (isprime(n)) {
         return std::make_shared<PrimesFftC>(n);
     }
-
-    //n=2^K
     if (ispow2(n)) {
-        return std::make_shared<Fft2Plan>(n);
+        return std::make_shared<Pow2FftPlan>(n);
     }
-
     return std::make_shared<FactorFFTPlan>(n);
 }
 
-//-------------------------------------------------------------------------------------------------
-class EvenFftPlanR : public BaseFftPlanR
-{
-public:
-    explicit EvenFftPlanR(int n)
-      : n_{n} {
-        DSPLIB_ASSERT(n % 2 == 0, "FFT size must be even");
-        fft_ = _get_fft_plan(n / 2);
-        w_ = expj(-2 * pi * arange(n / 2) / n);
-    }
-
-    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
-        using namespace std::complex_literals;
-        DSPLIB_ASSERT(x.size() == n_, "Input size must be equal FFT size");
-        const int n2 = n_ / 2;
-
-        arr_cmplx z(reinterpret_cast<const cmplx_t*>(x.data()), n2);
-        const auto Z = fft_->solve(z * 0.5);
-
-        arr_cmplx res(n_);
-
-        {
-            const auto Xe = Z[0] + conj(Z[0]);
-            const auto Xo = (conj(Z[0]) - Z[0]) * w_[0];
-            res[0].re = Xe.re - Xo.im;
-            res[0].im = Xe.im + Xo.re;
-        }
-
-        for (int i = 1; i < n2; ++i) {
-            const auto Zc = conj(Z[n2 - i]);
-            const auto Xe = Z[i] + Zc;
-            const auto Xo = (Zc - Z[i]) * w_[i];
-            res[i].re = Xe.re - Xo.im;
-            res[i].im = Xe.im + Xo.re;
-            res[n_ - i].re = res[i].re;
-            res[n_ - i].im = -res[i].im;
-        }
-
-        {
-            const auto Xe = Z[0] + conj(Z[0]);
-            const auto Xo = conj(Z[0]) - Z[0];
-            res[n2] = Xe.re + Xo.im;
-        }
-
-        return res;
-    }
-
-    [[nodiscard]] int size() const noexcept final {
-        return n_;
-    }
-
-private:
-    const int n_;
-    std::shared_ptr<BaseFftPlanC> fft_;
-    arr_cmplx w_;
-};
-
-//-------------------------------------------------------------------------------------------------
 std::shared_ptr<BaseFftPlanR> _get_rfft_plan(int n) {
     if (isprime(n)) {
         return std::make_shared<PrimesFftR>(n);
     }
-
     if (n % 2 == 0) {
-        return std::make_shared<EvenFftPlanR>(n);
+        return std::make_shared<RealFftPlan>(n);
     }
-
     return std::make_shared<FactorFFTPlanR>(n);
 }
 
@@ -208,6 +45,7 @@ std::shared_ptr<BaseFftPlanR> _get_rfft_plan(int n) {
 
 //-------------------------------------------------------------------------------------------------
 std::shared_ptr<BaseFftPlanC> create_fft_plan(int n) {
+    //TODO: use weak_ptr cache to prevent duplication
     thread_local LRUCache<int, std::shared_ptr<BaseFftPlanC>> cache{FFT_CACHE_SIZE};
     if (!cache.exists(n)) {
         auto plan = _get_fft_plan(n);
@@ -232,22 +70,18 @@ FftPlan::FftPlan(int n)
   : _d{create_fft_plan(n)} {
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx fft(const arr_cmplx& x) {
     auto plan = FftPlan(x.size());
     return plan(x);
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx fft(const arr_cmplx& x, int n) {
     if (n == x.size()) {
         return fft(x);
     }
-
     if (n > x.size()) {
         return fft(zeropad(x, n));
     }
-
     return fft(x.slice(0, n));
 }
 
@@ -256,22 +90,18 @@ FftPlanR::FftPlanR(int n)
   : _d{create_rfft_plan(n)} {
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx fft(const arr_real& x) {
     auto plan = FftPlanR(x.size());
     return plan(x);
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx fft(const arr_real& x, int n) {
     if (n == x.size()) {
         return fft(x);
     }
-
     if (n > x.size()) {
         return fft(zeropad(x, n));
     }
-
     return fft(x.slice(0, n));
 }
 

--- a/lib/fft/ifft.cpp
+++ b/lib/fft/ifft.cpp
@@ -4,28 +4,35 @@
 
 namespace dsplib {
 
-//-------------------------------------------------------------------------------------------------
+namespace {
+void _inplace_conj(arr_cmplx& x) {
+    for (auto& v : x) {
+        v.im = -v.im;
+    }
+}
+}   // namespace
+
 IfftPlan::IfftPlan(int n)
   : _d{std::make_shared<FftPlan>(n)} {
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx IfftPlan::operator()(const arr_cmplx& x) const {
     return this->solve(x);
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx IfftPlan::solve(const arr_cmplx& x) const {
-    const int n = x.size();
-    return conj(_d->solve(conj(x)) / n);
+    const real_t m = real_t(1) / x.size();
+    arr_cmplx y = x * m;
+    _inplace_conj(y);
+    y = _d->solve(y);
+    _inplace_conj(y);
+    return y;
 }
 
-//-------------------------------------------------------------------------------------------------
 int IfftPlan::size() const noexcept {
     return _d->size();
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx ifft(const arr_cmplx& x) {
     IfftPlan plan(x.size());
     return plan(x);

--- a/lib/fft/pow2-fft.h
+++ b/lib/fft/pow2-fft.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <dsplib/fft.h>
+#include <dsplib/math.h>
+
+#include "fft/dft-tables.h"
+
+namespace dsplib {
+
+class Pow2FftPlan : public BaseFftPlanC
+{
+public:
+    explicit Pow2FftPlan(int n)
+      : n_{n} {
+        const auto tb = fft_tables(n);
+        bitrev_ = tb.bitrev;
+        coeffs_ = _cos_to_cmplx(tb.coeffs.data(), tb.size);
+    }
+
+    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final {
+        const int n = x.size();
+        arr_cmplx y(n);
+        solve(x.data(), y.data(), n);
+        return y;
+    }
+
+    void solve(const cmplx_t* x, cmplx_t* y, int n) const final {
+        _fft(x, y, n);
+    }
+
+    [[nodiscard]] int size() const noexcept final {
+        return n_;
+    }
+
+private:
+    //cast cos table to complex for n==2^K
+    static std::vector<cmplx_t> _cos_to_cmplx(const real_t* w, int n) {
+        assert(ispow2(n));
+        const int n4 = (n / 4);
+        const int ms = (n - 1);
+        std::vector<cmplx_t> r(n);
+        for (int i = 0; i < n; ++i) {
+            r[i].re = w[i];
+            const int k = (i + n4) & ms;
+            r[i].im = w[k];
+        }
+        return r;
+    }
+
+    //bit reverse array permutation
+    static void _bitreverse(const cmplx_t* x, cmplx_t* y, const int32_t* bitrev, int n) noexcept {
+        const int n2 = n / 2;
+        for (int i = 0; i < n2; ++i) {
+            const auto kl = bitrev[i];
+            const auto kr = kl + 1;
+            y[i] = x[kl];
+            y[n2 + i] = x[kr];
+        }
+    }
+
+    static inline void _btrf(cmplx_t& x1, cmplx_t& x2, cmplx_t w) noexcept {
+        w *= x2;
+        x2 = x1 - w;
+        x1 = x1 + w;
+    }
+
+    void _fft(const cmplx_t* in, cmplx_t* out, int n) const {
+        assert((n == n_) && (n_ % 2) == 0);
+        assert(in != out);
+
+        //reverse sampling
+        _bitreverse(in, out, bitrev_.data(), n);
+
+        int h = 1;       ///< number of butterflies in clusters (and step between elements)
+        int m = n / 2;   ///< number of clusters (and step for the butterfly table)
+        int r = 2;       ///< number of elements (butterflies * 2) in clusters
+
+        cmplx_t* px = nullptr;         ///< pointer to go through the signal vector
+        const cmplx_t* pw = nullptr;   ///< pointer to go through the coefficient vector
+        const int L = nextpow2(n);     ///< number of DFT runs
+
+        //cascades
+        for (int i = 0; i < L; ++i) {
+            px = out;
+            //clusters
+            for (int j = 0; j < m; ++j) {
+                pw = coeffs_.data();
+                //butterflies
+                for (int k = 0; k < h; ++k) {
+                    _btrf(px[k], px[k + h], *pw);
+                    pw += m;
+                }
+                px += r;
+            }
+
+            //next cascade
+            m /= 2;
+            h *= 2;
+            r *= 2;
+        }
+    }
+
+    const int n_;
+    std::vector<int32_t> bitrev_;
+    std::vector<cmplx_t> coeffs_;
+};
+
+}   // namespace dsplib

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -22,7 +22,6 @@ public:
       : n_{n} {
         DSPLIB_ASSERT(isprime(n_), "`n` must be a prime number");
         if (n > MAX_DFT_SIZE) {
-            //TODO: create CZT from cache?
             const cmplx_t w = expj(-2 * pi / n);
             czt_ = std::make_shared<CztPlan>(n, n, w);
         } else if (n <= MAX_DFT_SIZE) {

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#include "dsplib/czt.h"
+#include "dsplib/fft.h"
+#include "dsplib/math.h"
+#include "dsplib/throw.h"
+#include "dsplib/utils.h"
+
+#include <cassert>
+#include <cstring>
+
+namespace dsplib {
+
+//boundary for calculating DFT instead of CZT
+constexpr int MAX_DFT_SIZE = 41;
+
+//--------------------------------------------------------------------------------
+class PrimesFftC : public BaseFftPlanC
+{
+public:
+    explicit PrimesFftC(int n)
+      : n_{n} {
+        DSPLIB_ASSERT(isprime(n_), "`n` must be a prime number");
+        if (n > MAX_DFT_SIZE) {
+            //TODO: create CZT from cache?
+            const cmplx_t w = expj(-2 * pi / n);
+            czt_ = std::make_shared<CztPlan>(n, n, w);
+        } else if (n <= MAX_DFT_SIZE) {
+            w_ = expj(-2 * pi * arange(n) / n).to_vec();
+            return;
+        }
+    }
+
+    [[nodiscard]] arr_cmplx solve(const arr_cmplx& x) const final {
+        arr_cmplx y(x);
+        _dft(y.data(), y.size());
+        return y;
+    }
+
+    [[nodiscard]] int size() const noexcept final {
+        return n_;
+    }
+
+    void solve(const cmplx_t* x, cmplx_t* y, int n) const final {
+        if (x != y) {
+            std::memcpy(y, x, n * sizeof(cmplx_t));
+        }
+        _dft(y, n);
+    }
+
+private:
+    static void _dft_n2(cmplx_t* x) noexcept {
+        cmplx_t y0, y1;
+
+        y0.re = x[0].re + x[1].re;
+        y0.im = x[0].im + x[1].im;
+
+        y1.re = (x[0].re - x[1].re);
+        y1.im = (x[0].im - x[1].im);
+
+        x[0] = y0;
+        x[1] = y1;
+    }
+
+    static void _dft_n3(cmplx_t* x) noexcept {
+        cmplx_t y0, y1, y2;
+        constexpr real_t c = -0.5;
+        constexpr real_t d = 0.866025403784439;
+
+        y0.re = x[0].re + x[1].re + x[2].re;
+        y0.im = x[0].im + x[1].im + x[2].im;
+
+        const real_t re1_c = x[1].re * c;
+        const real_t im1_d = x[1].im * d;
+        const real_t re2_c = x[2].re * c;
+        const real_t im2_d = x[2].im * d;
+        y1.re = x[0].re + (re1_c + im1_d) + (re2_c - im2_d);
+        y2.re = x[0].re + (re1_c - im1_d) + (re2_c + im2_d);
+
+        const real_t re1_d = x[1].re * d;
+        const real_t im1_c = x[1].im * c;
+        const real_t re2_d = x[2].re * d;
+        const real_t im2_c = x[2].im * c;
+        y1.im = x[0].im + (-re1_d + im1_c) + (re2_d + im2_c);
+        y2.im = x[0].im + (re1_d + im1_c) + (-re2_d + im2_c);
+
+        x[0] = y0;
+        x[1] = y1;
+        x[2] = y2;
+    }
+
+    static void _dft_slow(cmplx_t* x, int n, const cmplx_t* tw) noexcept {
+        cmplx_t y[MAX_DFT_SIZE];
+        std::memset(&y[0].re, 0, sizeof(y));
+
+        for (int i = 0; i < n; ++i) {
+            y[0] += x[i];
+        }
+
+        for (int k = 1; k < n; ++k) {
+            int iw = 0;
+            for (int i = 0; i < n; ++i) {
+                y[k] += x[i] * tw[iw];
+                iw += k;
+                iw = (iw < n) ? iw : (iw - n);
+            }
+        }
+
+        std::memcpy(x, y, n * sizeof(cmplx_t));
+    }
+
+    void _dft(cmplx_t* x, int n) const {
+        using namespace std::complex_literals;
+
+        assert(n == n_);
+
+        if (n == 2) {
+            _dft_n2(x);
+            return;
+        }
+
+        if (n == 3) {
+            _dft_n3(x);
+            return;
+        }
+
+        if (n <= MAX_DFT_SIZE) {
+            assert(!w_.empty());
+            _dft_slow(x, n, w_.data());
+            return;
+        }
+
+        //TODO: noexcept?
+        //TODO: call without copy
+        assert(czt_ && czt_->size() == n);
+        const auto y = czt_->solve(arr_cmplx(x, n));
+        std::memcpy(x, y.data(), n * sizeof(cmplx_t));
+    }
+
+    const int n_;
+    std::shared_ptr<CztPlan> czt_;
+    std::vector<cmplx_t> w_;
+};
+
+//--------------------------------------------------------------------------------
+class PrimesFftR : public BaseFftPlanR
+{
+public:
+    explicit PrimesFftR(int n)
+      : plan_{n} {
+    }
+
+    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
+        return plan_.solve(arr_cmplx(x));
+    }
+
+    [[nodiscard]] int size() const noexcept final {
+        return plan_.size();
+    }
+
+private:
+    PrimesFftC plan_;
+};
+
+}   // namespace dsplib

--- a/lib/fft/real-fft.h
+++ b/lib/fft/real-fft.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <dsplib/fft.h>
+#include <dsplib/utils.h>
+#include <dsplib/math.h>
+
+#include "fft/factory.h"
+
+namespace dsplib {
+
+class RealFftPlan : public BaseFftPlanR
+{
+public:
+    explicit RealFftPlan(int n)
+      : n_{n} {
+        DSPLIB_ASSERT(n % 2 == 0, "FFT size must be even");
+        fft_ = create_fft_plan(n / 2);
+        w_ = expj(-2 * pi * arange(n / 2) / n).to_vec();
+    }
+
+    [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
+        using namespace std::complex_literals;
+        DSPLIB_ASSERT(x.size() == n_, "Input size must be equal FFT size");
+        const int n2 = n_ / 2;
+
+        arr_cmplx z(reinterpret_cast<const cmplx_t*>(x.data()), n2);
+        const auto Z = fft_->solve(z * 0.5);
+
+        arr_cmplx res(n_);
+
+        {
+            const auto Xe = Z[0] + conj(Z[0]);
+            const auto Xo = (conj(Z[0]) - Z[0]) * w_[0];
+            res[0].re = Xe.re - Xo.im;
+            res[0].im = Xe.im + Xo.re;
+        }
+
+        for (int i = 1; i < n2; ++i) {
+            const auto Zc = conj(Z[n2 - i]);
+            const auto Xe = Z[i] + Zc;
+            const auto Xo = (Zc - Z[i]) * w_[i];
+            res[i].re = Xe.re - Xo.im;
+            res[i].im = Xe.im + Xo.re;
+            res[n_ - i].re = res[i].re;
+            res[n_ - i].im = -res[i].im;
+        }
+
+        {
+            const auto Xe = Z[0] + conj(Z[0]);
+            const auto Xo = conj(Z[0]) - Z[0];
+            res[n2] = Xe.re + Xo.im;
+        }
+
+        return res;
+    }
+
+    [[nodiscard]] int size() const noexcept final {
+        return n_;
+    }
+
+private:
+    const int n_;
+    std::shared_ptr<BaseFftPlanC> fft_;
+    std::vector<cmplx_t> w_;
+};
+
+}   // namespace dsplib

--- a/tests/fft_test.cpp
+++ b/tests/fft_test.cpp
@@ -3,6 +3,22 @@
 //-------------------------------------------------------------------------------------------------
 TEST(FFT, FftReal) {
     using namespace dsplib;
+    using namespace std::complex_literals;
+
+    {
+        auto x = arr_real{1, 2};
+        auto y = fft(x);
+        ASSERT_EQ_ARR_CMPLX(y, arr_cmplx{3, -1});
+    }
+
+    {
+        auto x = arr_real{1, 2, 3, 4, 5};
+        auto y1 = fft(x);
+        auto y2 = arr_cmplx{15.0000000000000 + 0.00000000000000i, -2.50000000000000 + 3.44095480117793i,
+                            -2.50000000000000 + 0.812299240582266i, -2.50000000000000 - 0.812299240582266i,
+                            -2.50000000000000 - 3.44095480117793i};
+        ASSERT_EQ_ARR_CMPLX(y1, y2);
+    }
 
     {
         int idx = 10;

--- a/tests/fft_test.cpp
+++ b/tests/fft_test.cpp
@@ -186,3 +186,29 @@ TEST(FFT, CztIFft2) {
         ASSERT_EQ_ARR_CMPLX(y1, y2);
     }
 }
+
+//-------------------------------------------------------------------------------------------------
+TEST(FFT, CztDft) {
+    using namespace dsplib;
+
+    auto dft = [](const arr_cmplx& x) -> arr_cmplx {
+        const int n = x.size();
+        arr_cmplx y(n);
+        for (int i = 0; i < n; ++i) {
+            const auto w = expj(-2 * pi * arange(n) * i / n);
+            y[i] = dot(x, w);
+        }
+        return y;
+    };
+
+    const auto sizes = arange(42, 511);
+    for (auto n : sizes) {
+        const arr_cmplx x = randn(n) + 1i * randn(n);
+        const auto y1 = dft(x);
+        cmplx_t w = expj(-2 * pi / n);
+        const auto y2 = czt(x, n, w);
+        const auto y3 = fft(x);
+        ASSERT_EQ_ARR_CMPLX(y1, y2);
+        ASSERT_EQ_ARR_CMPLX(y1, y3);
+    }
+}

--- a/tests/thread_safe_test.cpp
+++ b/tests/thread_safe_test.cpp
@@ -10,13 +10,11 @@
 TEST(ThreadSafe, FftCmplx) {
     using namespace dsplib;
 
-    std::vector<int> nfft_list = {128, 512, 1024, 4096, 8192};
     int test_steps = 1000;
     while (--test_steps) {
-        int idx = std::rand() % nfft_list.size();
-        int n = nfft_list[idx];
-        auto x1 = dsplib::randn(n);
-        auto x2 = x1;
+        const int n = 1L << randi({6, 13});
+        arr_cmplx x1 = dsplib::randn(n) + dsplib::randn(n) * 1i;
+        arr_cmplx x2 = x1;
 
         auto f1 = std::async([&]() {
             return dsplib::fft(x1);
@@ -28,7 +26,54 @@ TEST(ThreadSafe, FftCmplx) {
 
         auto y1 = f1.get();
         auto y2 = f2.get();
+        ASSERT_EQ_ARR_CMPLX(y1, y2);
+    }
+}
 
+//-------------------------------------------------------------------------------------------------
+TEST(ThreadSafe, FftReal) {
+    using namespace dsplib;
+
+    int test_steps = 1000;
+    while (--test_steps) {
+        const int n = 1L << randi({6, 13});
+        arr_real x1 = randn(n);
+        arr_real x2 = x1;
+
+        auto f1 = std::async([&]() {
+            return dsplib::fft(x1);
+        });
+
+        auto f2 = std::async([&]() {
+            return dsplib::fft(x2);
+        });
+
+        auto y1 = f1.get();
+        auto y2 = f2.get();
+        ASSERT_EQ_ARR_CMPLX(y1, y2);
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+TEST(ThreadSafe, FftNonPow2) {
+    using namespace dsplib;
+
+    int test_steps = 1000;
+    while (--test_steps) {
+        const int n = 1L << randi({6, 13});
+        arr_cmplx x1 = dsplib::randn(n);
+        arr_cmplx x2 = x1;
+
+        auto f1 = std::async([&]() {
+            return dsplib::fft(x1);
+        });
+
+        auto f2 = std::async([&]() {
+            return dsplib::fft(x2);
+        });
+
+        auto y1 = f1.get();
+        auto y2 = f2.get();
         ASSERT_EQ_ARR_CMPLX(y1, y2);
     }
 }


### PR DESCRIPTION
For all prime FFT sizes, the `PrimesFft` class is used. This speeds up the FFT for small sizes (previously the slow `CZT` was used by default). It also simplifies the FFT factorization code. The `PrimesFft` implementation uses regular `DFT` for small sizes or `CZT` for sizes greater than 41.