### PR TITLE
Prohibit implicit conversion of `arr_real` to `arr_cmplx`

### DIFF
--- a/benchs/fft.cpp
+++ b/benchs/fft.cpp
@@ -93,7 +93,7 @@ BENCHMARK(BM_FFTW3_DOUBLE)
 
 static void BM_FFT_DSPLIB(benchmark::State& state) {
     const int n = state.range(0);
-    dsplib::arr_cmplx x = dsplib::randn(n);
+    auto x = complex(dsplib::randn(n));
     dsplib::arr_cmplx y = dsplib::fft(x);   ///< update cache
     for (auto _ : state) {
         x[0] += 1e-5;

--- a/benchs/ifft.cpp
+++ b/benchs/ifft.cpp
@@ -4,7 +4,7 @@
 
 static void BM_IFFT_DSPLIB(benchmark::State& state) {
     const int n = state.range(0);
-    dsplib::arr_cmplx x = dsplib::randn(n);
+    auto x = complex(dsplib::randn(n));
     auto y = dsplib::fft(x);
     for (auto _ : state) {
         y[0] += 1e-10;

--- a/include/dsplib/array.h
+++ b/include/dsplib/array.h
@@ -22,6 +22,54 @@ using conditional_t = typename std::conditional_t<Cond_, Iftrue_, Iffalse_>;
 template<typename Bt, typename It>
 using ResultType = conditional_t<std::is_same_v<Bt, cmplx_t> || std::is_same_v<It, cmplx_t>, cmplx_t, real_t>;
 
+template<typename T_dst, typename T_src>
+base_array<T_dst> array_cast(const base_array<T_src>& src) noexcept {
+    static_assert(is_scalar_v<T_src> && is_scalar_v<T_dst>, "types must be scalar");
+    static_assert(!(is_complex_v<T_src> && !is_complex_v<T_dst>), "complex to real cast is not allowed");
+    if constexpr (std::is_same_v<T_src, T_dst>) {
+        return src;
+    } else if constexpr (!is_complex_v<T_src> && is_complex_v<T_dst>) {
+        base_array<T_dst> dst(src.size());
+        for (int i = 0; i < src.size(); ++i) {
+            dst[i].re = static_cast<real_t>(src[i]);
+        }
+        return dst;
+    } else {
+        return base_array<T_dst>(src);
+    }
+}
+
+//rules for implicit array conversion
+//TODO: use static_assert and verbose error message
+template<typename T_src, typename T_dst>
+constexpr bool is_array_castable() noexcept {
+    if constexpr (!std::is_convertible_v<T_src, T_dst>) {
+        return false;
+    }
+
+    //only arithmetic scalar
+    if constexpr (!is_scalar_v<T_src> || !is_scalar_v<T_dst>) {
+        return false;
+    }
+
+    //cmplx -> real
+    if constexpr (is_complex_v<T_src> && !is_complex_v<T_dst>) {
+        return false;
+    }
+
+    //real -> cmplx
+    if constexpr (!is_complex_v<T_src> && is_complex_v<T_dst>) {
+        return false;
+    }
+
+    //float -> int
+    if constexpr (std::is_floating_point_v<T_src> && std::is_integral_v<T_dst>) {
+        return false;
+    }
+
+    return true;
+}
+
 //base dsplib array type
 //TODO: add array_view as parent for array/slice
 //TODO: add slice(vector<bool>)
@@ -50,7 +98,7 @@ public:
 
     template<typename T2>
     base_array(const std::vector<T2>& v) {
-        static_assert(std::is_convertible<T2, T>::value, "Type is not convertible");
+        static_assert(is_array_castable<T2, T>(), "only real->real, cmplx->cmplx array cast support");
         _vec.assign(v.begin(), v.end());
     }
 
@@ -62,9 +110,9 @@ public:
       : _vec(v._vec) {
     }
 
-    template<class T2>
+    template<typename T2>
     base_array(const base_array<T2>& v) {
-        static_assert(std::is_convertible<T2, T>::value, "Type is not convertible");
+        static_assert(is_array_castable<T2, T>(), "only real->real, cmplx->cmplx array cast support");
         _vec.assign(v.begin(), v.end());
     }
 
@@ -78,7 +126,7 @@ public:
 
     template<typename T2>
     explicit base_array(const T2* x, size_t nx) {
-        static_assert(std::is_convertible<T2, T>::value, "Type is not convertible");
+        static_assert(is_array_castable<T2, T>(), "only real->real, cmplx->cmplx array cast support");
         _vec.insert(_vec.end(), x, x + nx);
     }
 
@@ -294,7 +342,7 @@ public:
     //--------------------------------------------------------------------
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator+=(const T2& rhs) noexcept {
-        static_assert(std::is_same_v<T, R>, "The operation changes the type");
+        static_assert(std::is_same_v<T, R>, "the operation changes the type");
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] += rhs;
         }
@@ -303,7 +351,7 @@ public:
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator-=(const T2& rhs) noexcept {
-        static_assert(std::is_same_v<T, R>, "The operation changes the type");
+        static_assert(std::is_same_v<T, R>, "the operation changes the type");
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] -= rhs;
         }
@@ -312,7 +360,7 @@ public:
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator*=(const T2& rhs) noexcept {
-        static_assert(std::is_same_v<T, R>, "The operation changes the type");
+        static_assert(std::is_same_v<T, R>, "the operation changes the type");
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] *= rhs;
         }
@@ -321,7 +369,7 @@ public:
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator/=(const T2& rhs) {
-        static_assert(std::is_same_v<T, R>, "The operation changes the type");
+        static_assert(std::is_same_v<T, R>, "the operation changes the type");
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] /= rhs;
         }
@@ -331,28 +379,29 @@ public:
     //--------------------------------------------------------------------
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator+(const T2& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
+        //TODO: optimize, not optimal for arr_cmplx + real_t
         temp += rhs;
         return temp;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator-(const T2& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp -= rhs;
         return temp;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator*(const T2& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp *= rhs;
         return temp;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator/(const T2& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp /= rhs;
         return temp;
     }
@@ -386,55 +435,47 @@ public:
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator*=(const base_array<T2>& rhs) {
-        if (this->size() != rhs.size()) {
-            DSPLIB_THROW("array sizes are different");
-        }
-
+        DSPLIB_ASSERT(this->size() == rhs.size(), "arrays sizes must be equal");
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] *= rhs[i];
         }
-
         return *this;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R>& operator/=(const base_array<T2>& rhs) {
-        if (this->size() != rhs.size()) {
-            DSPLIB_THROW("array sizes are different");
-        }
-
+        DSPLIB_ASSERT(this->size() == rhs.size(), "arrays sizes must be equal");
         for (size_t i = 0; i < _vec.size(); ++i) {
             _vec[i] /= rhs[i];
         }
-
         return *this;
     }
 
     //--------------------------------------------------------------------
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator+(const base_array<T2>& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp += rhs;
         return temp;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator-(const base_array<T2>& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp -= rhs;
         return temp;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator*(const base_array<T2>& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp *= rhs;
         return temp;
     }
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator/(const base_array<T2>& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp /= rhs;
         return temp;
     }
@@ -449,7 +490,7 @@ public:
 
     template<class T2, class R = ResultType<T, T2>>
     base_array<R> operator|(const base_array<T2>& rhs) const {
-        base_array<R> temp(*this);
+        auto temp = array_cast<R>(*this);
         temp |= rhs;
         return temp;
     }
@@ -459,7 +500,7 @@ public:
         if constexpr (std::is_same_v<T, R>) {
             return _vec;
         } else {
-            static_assert(std::is_convertible<T, R>::value, "Type is not convertible");
+            static_assert(std::is_convertible<T, R>::value, "type is not convertible");
             return std::vector<R>(_vec.begin(), _vec.end());
         }
     }
@@ -488,7 +529,7 @@ inline base_array<R> operator+(const Scalar& lhs, const base_array<T>& rhs) {
 template<class T, class Scalar, class R = ResultType<T, Scalar>, class S_ = typename enable_scalar_t<Scalar>::type,
          class C_ = typename enable_convertible_t<Scalar, R>::type>
 inline base_array<R> operator-(const Scalar& lhs, const base_array<T>& rhs) {
-    base_array<R> r(rhs);
+    auto r = array_cast<R>(rhs);
     for (int i = 0; i < r.size(); ++i) {
         r[i] = R(lhs) - rhs[i];
     }
@@ -504,7 +545,7 @@ inline base_array<R> operator*(const Scalar& lhs, const base_array<T>& rhs) {
 template<class T, class Scalar, class R = ResultType<T, Scalar>, class S_ = typename enable_scalar_t<Scalar>::type,
          class C_ = typename enable_convertible_t<Scalar, R>::type>
 inline base_array<R> operator/(const Scalar& lhs, const base_array<T>& rhs) {
-    base_array<R> r(rhs);
+    auto r = array_cast<R>(rhs);
     for (int i = 0; i < r.size(); ++i) {
         r[i] = R(lhs) / rhs[i];
     }

--- a/include/dsplib/lms.h
+++ b/include/dsplib/lms.h
@@ -46,8 +46,8 @@ public:
         }
 
         int nx = x.size();
-        base_array<T> y = zeros(nx);
-        base_array<T> e = zeros(nx);
+        base_array<T> y(nx);
+        base_array<T> e(nx);
         base_array<T> tu = _u | x;
         arr_real tu2 = (_method == LmsType::NLMS) ? abs2(tu) : arr_real{};
 

--- a/include/dsplib/math.h
+++ b/include/dsplib/math.h
@@ -129,6 +129,7 @@ constexpr real_t conj(real_t x) {
 
 //complex vector formation
 arr_cmplx complex(const arr_real& re, const arr_real& im);
+arr_cmplx complex(const arr_real& re) noexcept;
 
 //the nearest power of two numbers (with rounding up)
 int nextpow2(int m);

--- a/include/dsplib/types.h
+++ b/include/dsplib/types.h
@@ -63,7 +63,23 @@ double eps(double v);
 real_t eps();
 
 template<typename T>
-struct is_scalar : std::integral_constant<bool, std::is_arithmetic_v<T> || std::is_same_v<T, cmplx_t>>
+struct is_std_complex
+  : std::integral_constant<bool, std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>> ||
+                                   std::is_same_v<T, std::complex<int>>>
+{};
+
+template<typename T>
+constexpr bool is_std_complex_v = is_std_complex<T>::value;
+
+template<typename T>
+struct is_complex : std::integral_constant<bool, is_std_complex<T>::value || std::is_same_v<T, cmplx_t>>
+{};
+
+template<typename T>
+constexpr bool is_complex_v = is_complex<T>::value;
+
+template<typename T>
+struct is_scalar : std::integral_constant<bool, std::is_arithmetic_v<T> || is_complex_v<T>>
 {};
 
 template<typename T>

--- a/include/dsplib/types.h
+++ b/include/dsplib/types.h
@@ -22,19 +22,16 @@ constexpr std::complex<T> operator+(const int& lhs, const std::complex<T>& rhs) 
     return std::complex<T>(T(lhs)) + rhs;
 }
 
-//-------------------------------------------------------------------------------------------------
 template<typename T>
 constexpr std::complex<T> operator-(const int& lhs, const std::complex<T>& rhs) {
     return std::complex<T>(T(lhs)) - rhs;
 }
 
-//-------------------------------------------------------------------------------------------------
 template<typename T>
 constexpr std::complex<T> operator+(const std::complex<T>& lhs, const int& rhs) {
     return lhs + std::complex<T>(T(rhs));
 }
 
-//-------------------------------------------------------------------------------------------------
 template<typename T>
 constexpr std::complex<T> operator-(const std::complex<T>& lhs, const int& rhs) {
     return lhs - std::complex<T>(T(rhs));
@@ -86,13 +83,16 @@ template<typename T>
 constexpr bool is_scalar_v = is_scalar<T>::value;
 
 template<typename T>
-using enable_scalar_t = std::enable_if<is_scalar_v<T>>;
+using enable_scalar = std::enable_if<is_scalar_v<T>>;
+
+template<typename T>
+using enable_scalar_t = typename enable_scalar<T>::type;
 
 template<typename T, typename T2>
-using enable_convertible_t = std::enable_if<std::is_convertible_v<T, T2>>;
+using enable_convertible = std::enable_if<std::is_convertible_v<T, T2>>;
 
-template<typename T1, typename T2>
-using enable_same_t = std::enable_if<std::is_same_v<T1, T2>>;
+template<typename T, typename T2>
+using enable_convertible_t = typename enable_convertible<T, T2>::type;
 
 //-------------------------------------------------------------------------------------------------
 //basic complex type
@@ -240,26 +240,22 @@ struct cmplx_t
 };
 
 //left oriented real * cmplx
-template<class T, class S_ = typename enable_scalar_t<T>::type,
-         class C_ = typename enable_convertible_t<T, cmplx_t>::type>
+template<class T, class S_ = enable_scalar_t<T>, class C_ = enable_convertible_t<T, cmplx_t>>
 constexpr cmplx_t operator+(const T& lhs, const cmplx_t& rhs) {
     return rhs + lhs;
 }
 
-template<class T, class S_ = typename enable_scalar_t<T>::type,
-         class C_ = typename enable_convertible_t<T, cmplx_t>::type>
+template<class T, class S_ = enable_scalar_t<T>, class C_ = enable_convertible_t<T, cmplx_t>>
 constexpr cmplx_t operator-(const T& lhs, const cmplx_t& rhs) {
     return {lhs - rhs.re, -rhs.im};
 }
 
-template<class T, class S_ = typename enable_scalar_t<T>::type,
-         class C_ = typename enable_convertible_t<T, cmplx_t>::type>
+template<class T, class S_ = enable_scalar_t<T>, class C_ = enable_convertible_t<T, cmplx_t>>
 constexpr cmplx_t operator*(const T& lhs, const cmplx_t& rhs) {
     return rhs * lhs;
 }
 
-template<class T, class S_ = typename enable_scalar_t<T>::type,
-         class C_ = typename enable_convertible_t<T, cmplx_t>::type>
+template<class T, class S_ = enable_scalar_t<T>, class C_ = enable_convertible_t<T, cmplx_t>>
 constexpr cmplx_t operator/(const T& lhs, const cmplx_t& rhs) {
     return cmplx_t(lhs) / rhs;
 }

--- a/lib/fft/fact-fft.h
+++ b/lib/fft/fact-fft.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <dsplib/math.h>
 #include <dsplib/fft.h>
 
 #include <memory>
@@ -35,7 +36,7 @@ public:
 
     [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
         //TODO: real optimization (for odd sizes)
-        return _plan.solve(arr_cmplx(x));
+        return _plan.solve(complex(x));
     }
 
     [[nodiscard]] int size() const noexcept final {

--- a/lib/fft/primes-fft.h
+++ b/lib/fft/primes-fft.h
@@ -125,7 +125,7 @@ public:
     }
 
     [[nodiscard]] arr_cmplx solve(const arr_real& x) const final {
-        return plan_.solve(arr_cmplx(x));
+        return plan_.solve(complex(x));
     }
 
     [[nodiscard]] int size() const noexcept final {

--- a/lib/fir.cpp
+++ b/lib/fir.cpp
@@ -43,14 +43,14 @@ FftFilter::FftFilter(const arr_cmplx& h)
     const int fft_len = 1L << nextpow2(2 * h.size());
     _n = fft_len - h.size() + 1;
     assert(_n > _m);
-    _olap = zeros(_m - 1);
+    _olap = complex(zeros(_m - 1));
     _h = fft(conj(h), fft_len);
-    _x = zeros(fft_len);
+    _x = complex(zeros(fft_len));
 }
 
 //-------------------------------------------------------------------------------------------------
 FftFilter::FftFilter(const arr_real& h)
-  : FftFilter(arr_cmplx(h)) {
+  : FftFilter(complex(h)) {
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -83,7 +83,7 @@ arr_cmplx FftFilter::process(const arr_cmplx& x) {
 //-------------------------------------------------------------------------------------------------
 arr_real FftFilter::process(const arr_real& x) {
     //TODO: real optimization
-    return real(process(arr_cmplx(x)));
+    return real(process(complex(x)));
 }
 
 //----------------------------------------------------------------------------------------------

--- a/lib/hilbert.cpp
+++ b/lib/hilbert.cpp
@@ -29,7 +29,7 @@ arr_cmplx HilbertFilter::design_fir(int flen, real_t fs, real_t f1) {
 
     const auto lm = power(arange(k1 - 1) / (k1 - 1), 8);
     const auto rm = flip(lm);
-    const arr_cmplx H = lm | ones(k2 - k1 + 1) | rm | zeros(N / 2 - 1);
+    const arr_cmplx H = complex(lm | ones(k2 - k1 + 1) | rm | zeros(N / 2 - 1));
     const arr_cmplx h = ifft(H);   // desired impulse response
 
     const auto w = window::kaiser(M, 8);

--- a/lib/math.cpp
+++ b/lib/math.cpp
@@ -294,6 +294,10 @@ arr_cmplx complex(const arr_real& re, const arr_real& im) {
     return r;
 }
 
+arr_cmplx complex(const arr_real& re) noexcept {
+    return array_cast<cmplx_t>(re);
+}
+
 //-------------------------------------------------------------------------------------------------
 arr_real log(const arr_real& arr) {
     arr_real r(arr.size());
@@ -448,7 +452,7 @@ arr_cmplx power(const arr_cmplx& x, real_t n) {
 template<typename T>
 static base_array<T> _power(const base_array<T>& x, int n) {
     if (n == 0) {
-        return ones(x.size());
+        return array_cast<T>(ones(x.size()));
     }
     if (n == 1) {
         return x;

--- a/lib/xcorr.cpp
+++ b/lib/xcorr.cpp
@@ -27,12 +27,12 @@ arr_cmplx xcorr(const arr_cmplx& x1, const arr_cmplx& x2) {
 
 //-------------------------------------------------------------------------------------------------
 arr_real xcorr(const arr_real& x1, const arr_real& x2) {
-    return real(xcorr(arr_cmplx(x1), arr_cmplx(x2)));
+    return real(xcorr(complex(x1), complex(x2)));
 }
 
 //-------------------------------------------------------------------------------------------------
 arr_real xcorr(const arr_real& x) {
-    return real(xcorr(arr_cmplx(x), arr_cmplx(x)));
+    return real(xcorr(complex(x), complex(x)));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/tests/arr_cmpl_test.cpp
+++ b/tests/arr_cmpl_test.cpp
@@ -20,13 +20,6 @@ TEST(ArrCmplxTest, Init) {
     ASSERT_TRUE(a1.empty());
     ASSERT_TRUE(a3.empty());
 
-    std::vector<short> v1 = {-1, -2, 3, 4};
-    arr_cmplx a8(v1.data(), v1.size());
-    for (int i = 0; i < 4; ++i) {
-        ASSERT_FLOAT_EQ(v1[i], a8[i].re);
-        ASSERT_FLOAT_EQ(0, a8[i].im);
-    }
-
     std::vector<cmplx_t> v2 = {1 + 1i, 2 + 2i, 3 + 3i, 4 + 4i};
     arr_cmplx a9(v2);
     ASSERT_EQ_ARR_CMPLX(v2, a9);
@@ -166,7 +159,7 @@ TEST(ArrCmplxTest, UnpackStdComplex) {
 TEST(ArrCmplxTest, VecToArray) {
     {
         std::vector<short> x = {1, 2, -3, -2};
-        arr_cmplx a1(x);
+        arr_cmplx a1 = complex(arr_real(x));
         arr_cmplx a2 = {1 + 0i, 2 + 0i, -3 + 0i, -2 + 0i};
         ASSERT_EQ_ARR_CMPLX(a1, a2);
     }

--- a/tests/detector_test.cpp
+++ b/tests/detector_test.cpp
@@ -23,7 +23,7 @@ TEST(PreambleDetector, SingleDetect) {
     ASSERT_EQ(finddelay(ref, result->preamble), 0);
 
     ASSERT_ANY_THROW({
-        auto x = zeros(dtc.frame_len() + 1);
+        auto x = complex(zeros(dtc.frame_len() + 1));
         auto r = dtc.process(x);
     });
 }

--- a/tests/fft_test.cpp
+++ b/tests/fft_test.cpp
@@ -42,23 +42,23 @@ TEST(FFT, FftReal) {
 
     {
         const arr_real x = randn(1024);
-        ASSERT_EQ_ARR_CMPLX(fft(x), fft(arr_cmplx(x)));
+        ASSERT_EQ_ARR_CMPLX(fft(x), fft(complex(x)));
     }
 
     {
         const arr_real x = randn(500);
-        ASSERT_EQ_ARR_CMPLX(fft(x), fft(arr_cmplx(x)));
+        ASSERT_EQ_ARR_CMPLX(fft(x), fft(complex(x)));
     }
 
     {
         const arr_real x = sin(2 * pi * arange(500) * 0.01);
-        ASSERT_EQ_ARR_CMPLX(fft(x), fft(arr_cmplx(x)));
+        ASSERT_EQ_ARR_CMPLX(fft(x), fft(complex(x)));
     }
 
     {
         //3 * 101
         const arr_real x = randn(303);
-        ASSERT_EQ_ARR_CMPLX(fft(x), fft(arr_cmplx(x)));
+        ASSERT_EQ_ARR_CMPLX(fft(x), fft(complex(x)));
     }
 
     {
@@ -98,7 +98,7 @@ TEST(FFT, FftCmplx) {
 
     {
         const int n = 128;
-        const arr_cmplx x = sin(2 * pi * arange(n) * 0.1);
+        const auto x = complex(sin(2 * pi * arange(n) * 0.1));
         const arr_cmplx y = fft(x).slice(0, n / 2 + 1);
         ASSERT_EQ(argmax(y), 13);
         ASSERT_CMPLX_NEAR(max(y), cmplx_t{-34.4803383753629 - 48.7604203346960i});
@@ -155,14 +155,14 @@ TEST(FFT, Czt) {
     arr_real x = {1.0, 2.0, 3.0};
     const int m = x.size();
     cmplx_t w = expj(-2 * pi / m);
-    auto czt_res = czt(x, m, w);
+    auto czt_res = czt(complex(x), m, w);
     ASSERT_EQ_ARR_CMPLX(czt_res, dft_ref);
 }
 
 //-------------------------------------------------------------------------------------------------
 TEST(FFT, CztPrime) {
     const int n = 31;
-    arr_cmplx x = arange(n);
+    arr_cmplx x = complex(arange(n));
     arr_cmplx r = {465.000000000000 + 4.97379915032070e-14i, -15.5000000000000 + 152.423942689195i,
                    -15.5000000000000 + 75.4238733733689i,    -15.5000000000000 + 49.4020717291786i,
                    -15.5000000000000 + 36.1192711999180i,    -15.5000000000000 + 27.9256495884725i,
@@ -255,7 +255,7 @@ TEST(FFT, SmallFft) {
         arr_real x = {10};
         arr_cmplx ref = {10};
         auto y1 = plan_r.solve(x);
-        auto y2 = plan_c.solve(x);
+        auto y2 = plan_c.solve(complex(x));
         auto y3 = fft(x);
         ASSERT_EQ_ARR_CMPLX(y1, ref);
         ASSERT_EQ_ARR_CMPLX(y2, ref);
@@ -267,7 +267,7 @@ TEST(FFT, SmallFft) {
         arr_real x = {1, 2};
         arr_cmplx ref = {3, -1};
         auto y1 = plan_r.solve(x);
-        auto y2 = plan_c.solve(x);
+        auto y2 = plan_c.solve(complex(x));
         auto y3 = fft(x);
         ASSERT_EQ_ARR_CMPLX(y1, ref);
         ASSERT_EQ_ARR_CMPLX(y2, ref);
@@ -280,7 +280,7 @@ TEST(FFT, SmallFft) {
         arr_cmplx ref = {10.0000000000000 + 0.00000000000000i, -2.00000000000000 + 2.00000000000000i,
                          -2.00000000000000 + 0.00000000000000i, -2.00000000000000 - 2.00000000000000i};
         auto y1 = plan_r.solve(x);
-        auto y2 = plan_c.solve(x);
+        auto y2 = plan_c.solve(complex(x));
         auto y3 = fft(x);
         ASSERT_EQ_ARR_CMPLX(y1, ref);
         ASSERT_EQ_ARR_CMPLX(y2, ref);
@@ -295,7 +295,7 @@ TEST(FFT, SmallFft) {
                          -4.00000000000000 + 0.00000000000000i, -4.00000000000000 - 1.65685424949238i,
                          -4.00000000000000 - 4.00000000000000i, -4.00000000000000 - 9.65685424949238i};
         auto y1 = plan_r.solve(x);
-        auto y2 = plan_c.solve(x);
+        auto y2 = plan_c.solve(complex(x));
         auto y3 = fft(x);
         ASSERT_EQ_ARR_CMPLX(y1, ref);
         ASSERT_EQ_ARR_CMPLX(y2, ref);

--- a/tests/fir_test.cpp
+++ b/tests/fir_test.cpp
@@ -70,7 +70,7 @@ TEST(FirTest, CmplxFftFir) {
 
 //-------------------------------------------------------------------------------------------------
 static arr_cmplx _get_bandpass_fir(int len, double f0, double f1) {
-    arr_cmplx H = zeros(len);
+    auto H = complex(zeros(len));
     auto t0 = int(f0 * len);
     auto t1 = int(f1 * len);
     H.slice(t0, t1) = 1;

--- a/tests/thread_safe_test.cpp
+++ b/tests/thread_safe_test.cpp
@@ -61,7 +61,7 @@ TEST(ThreadSafe, FftNonPow2) {
     int test_steps = 1000;
     while (--test_steps) {
         const int n = randi({100, 2000});
-        arr_cmplx x1 = dsplib::randn(n);
+        auto x1 = complex(dsplib::randn(n));
         arr_cmplx x2 = x1;
 
         auto f1 = std::async([&]() {

--- a/tests/types_test.cpp
+++ b/tests/types_test.cpp
@@ -4,7 +4,7 @@
 using namespace dsplib;
 
 //-------------------------------------------------------------------------------------------------
-TEST(Template, CmplxConvert) {
+TEST(Template, CmplxScalarConvert) {
     //scalar -> cmplx_t
     ASSERT_TRUE(bool(std::is_convertible<double, cmplx_t>::value));
     ASSERT_TRUE(bool(std::is_convertible<cmplx_t, cmplx_t>::value));
@@ -32,4 +32,31 @@ TEST(Template, CmplxConvert) {
 TEST(Template, IsScalar) {
     ASSERT_TRUE(bool(is_scalar_v<cmplx_t>));
     ASSERT_TRUE(bool(is_scalar_v<real_t>));
+}
+
+//-------------------------------------------------------------------------------------------------
+TEST(Template, ArrayConvert) {
+    {
+        ASSERT_TRUE(bool(is_array_convertible<float, double>()));
+        dsplib::base_array<float> x(dsplib::base_array<double>(10));
+    }
+
+    {
+        ASSERT_TRUE(bool(is_array_convertible<double, float>()));
+        dsplib::base_array<double> x(dsplib::base_array<float>(10));
+    }
+
+    {
+        ASSERT_FALSE(bool(is_array_convertible<float, int>()));
+        ASSERT_TRUE(bool(is_array_convertible<int, float>()));
+        dsplib::base_array<float> x(dsplib::base_array<int>(10));
+    }
+
+    {
+        ASSERT_TRUE(bool(is_array_convertible<std::complex<real_t>, cmplx_t>()));
+        dsplib::base_array<cmplx_t> x(dsplib::base_array<std::complex<real_t>>(10));
+    }
+
+    ASSERT_FALSE(bool(is_array_convertible<real_t, cmplx_t>()));
+    ASSERT_FALSE(bool(is_array_convertible<cmplx_t, real_t>()));
 }


### PR DESCRIPTION
Now the `complex` or `array_cast<T>` functions are used to convert to a complex array. 
This will allow us to switch to `span<T>` function arguments in the future instead of `base_array<T>`. 
Previously, this was not possible due to ambiguity.