### PR TITLE
inplace span support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,6 @@ if (DSPLIB_FFT_BACKEND STREQUAL "fftw")
     endif()
     set(FFT_INCLUDES ${FFTW_INCLUDES})
     set(DSPLIB_EXCLUDE_FFT ON)
-    set(DSPLIB_FFT_CACHE_SIZE 0) # FFTW has its own cache
 elseif (DSPLIB_FFT_BACKEND STREQUAL "ne10")
     find_package(NE10 REQUIRED)
     if (DSPLIB_USE_FLOAT32)

--- a/include/dsplib/czt.h
+++ b/include/dsplib/czt.h
@@ -18,10 +18,6 @@ public:
 
     [[nodiscard]] int size() const noexcept final;
 
-    arr_cmplx operator()(span_t<cmplx_t> x) const {
-        return this->solve(x);
-    }
-
 private:
     std::shared_ptr<CztPlanImpl> _d;
 };

--- a/include/dsplib/fft.h
+++ b/include/dsplib/fft.h
@@ -25,6 +25,14 @@ public:
         r = this->solve(x);
     }
 
+    //inplace FFT implementation
+    virtual void solve(inplace_cmplx inp) const {
+        //default non optimal implementation with temp array
+        auto x = inp.get();
+        const auto y = this->solve(x);
+        x.assign(y);
+    }
+
     [[nodiscard]] virtual int size() const noexcept = 0;
 };
 

--- a/include/dsplib/iterator.h
+++ b/include/dsplib/iterator.h
@@ -55,14 +55,6 @@ struct SliceIterator
         return lhs.ptr_ != rhs.ptr_;
     };
 
-    friend bool operator>(const SliceIterator& lhs, const SliceIterator& rhs) noexcept {
-        return lhs.ptr_ > rhs.ptr_;
-    };
-
-    friend bool operator<(const SliceIterator& lhs, const SliceIterator& rhs) noexcept {
-        return lhs.ptr_ < rhs.ptr_;
-    };
-
 private:
     pointer ptr_;
     int step_{1};

--- a/include/dsplib/math.h
+++ b/include/dsplib/math.h
@@ -7,6 +7,8 @@
 
 namespace dsplib {
 
+//TODO: mark noexcept
+
 //exponential
 arr_real exp(const arr_real& arr);
 real_t exp(real_t v);
@@ -53,20 +55,23 @@ int argmin(span_real arr);
 int argmin(span_cmplx arr);
 
 //absolute value and complex magnitude
-arr_real abs(const arr_real& arr);
-real_t abs(real_t v);
-arr_real abs(const arr_cmplx& arr);
-real_t abs(cmplx_t v);
+arr_real abs(const arr_real& arr) noexcept;
+real_t abs(real_t v) noexcept;
+arr_real abs(const arr_cmplx& arr) noexcept;
+real_t abs(cmplx_t v) noexcept;
+void abs(inplace_real arr) noexcept;
 
 //phase angle in the interval [-pi, pi] for each element of a complex array z
 arr_real angle(const arr_cmplx& arr);
 real_t angle(cmplx_t v);
 
 //round
-real_t round(const real_t& x);
-cmplx_t round(const cmplx_t& x);
-arr_real round(const arr_real& arr);
-arr_cmplx round(const arr_cmplx& arr);
+real_t round(const real_t& x) noexcept;
+cmplx_t round(const cmplx_t& x) noexcept;
+arr_real round(const arr_real& arr) noexcept;
+arr_cmplx round(const arr_cmplx& arr) noexcept;
+void round(inplace_real arr) noexcept;
+void round(inplace_cmplx arr) noexcept;
 
 //array sum
 real_t sum(const arr_real& arr);
@@ -113,7 +118,9 @@ arr_real imag(const arr_cmplx& x);
 real_t imag(const cmplx_t& x);
 
 //complex pairing
-arr_cmplx conj(const arr_cmplx& x);
+arr_cmplx conj(const arr_cmplx& x) noexcept;
+
+void conj(inplace_cmplx x) noexcept;
 
 constexpr cmplx_t conj(const cmplx_t& x) noexcept {
     return x.conj();
@@ -181,8 +188,9 @@ arr_cmplx power(const arr_cmplx& x, int n);
 
 //square root (only positive values)
 //TODO: add complex result for negative or complex input
-real_t sqrt(real_t x);
-arr_real sqrt(const arr_real& x);
+real_t sqrt(real_t x) noexcept;
+arr_real sqrt(const arr_real& arr) noexcept;
+void sqrt(inplace_real arr) noexcept;
 
 //array log
 arr_real log(const arr_real& arr);
@@ -210,7 +218,7 @@ arr_real upsample(const arr_real& arr, int n, int phase = 0);
 arr_cmplx upsample(const arr_cmplx& arr, int n, int phase = 0);
 
 //abs(x)^2
-arr_real abs2(const arr_cmplx& x);
+arr_real abs2(const arr_cmplx& x) noexcept;
 
 constexpr real_t abs2(const cmplx_t& x) noexcept {
     return x.abs2();
@@ -269,16 +277,20 @@ inline cmplx_t sign(const cmplx_t& x) noexcept {
 
 //----------------------------------------------------------------------------------------
 //convert power <-> decibels: db = 10 * log10(pow)
-real_t pow2db(real_t v);
-arr_real pow2db(const arr_real& v);
-real_t db2pow(real_t v);
-arr_real db2pow(const arr_real& v);
+real_t pow2db(real_t v) noexcept;
+arr_real pow2db(const arr_real& arr) noexcept;
+real_t db2pow(real_t v) noexcept;
+arr_real db2pow(const arr_real& arr) noexcept;
+void pow2db(inplace_real arr) noexcept;
+void db2pow(inplace_real arr) noexcept;
 
 //convert magnitude <-> decibels: db = 20 * log10(mag)
-real_t mag2db(real_t v);
-arr_real mag2db(const arr_real& v);
-real_t db2mag(real_t v);
-arr_real db2mag(const arr_real& v);
+real_t mag2db(real_t v) noexcept;
+arr_real mag2db(const arr_real& arr) noexcept;
+real_t db2mag(real_t v) noexcept;
+arr_real db2mag(const arr_real& arr) noexcept;
+void mag2db(inplace_real arr) noexcept;
+void db2mag(inplace_real arr) noexcept;
 
 //----------------------------------------------------------------------------------------
 //check that the number is prime

--- a/include/dsplib/utils.h
+++ b/include/dsplib/utils.h
@@ -40,24 +40,6 @@ inline arr_real arange(int stop) {
     return arange(0, stop, 1);
 }
 
-//-----------------------------------------------------------------------------------------------------------
-template<typename T1, typename T2, typename T3, class R = typename enable_if_some_float_t<T1, T2, T3>::type>
-[[deprecated("Use arange() instead.")]] arr_real range(T1 start, T2 stop, T3 step = 1) {
-    return arange(start, stop, step);
-}
-
-[[deprecated("Use arange() instead.")]] inline arr_real range(real_t stop) {
-    return arange(0.0, stop, 1.0);
-}
-
-[[deprecated("Use arange() instead.")]] inline arr_real range(int start, int stop, int step = 1) {
-    return arange(start, stop, step);
-}
-
-[[deprecated("Use arange() instead.")]] inline arr_real range(int stop) {
-    return arange(stop);
-}
-
 //join a sequence of arrays
 //TODO: add slice args?
 arr_real concatenate(span_real x1, span_real x2, span_real x3 = {}, span_real x4 = {}, span_real x5 = {});
@@ -82,6 +64,8 @@ arr_cmplx repelem(const arr_cmplx& x, int n);
 //flip order of elements
 arr_real flip(const arr_real& x);
 arr_cmplx flip(const arr_cmplx& x);
+void flip(inplace_real x);
+void flip(inplace_cmplx x);
 
 enum class dtype
 {
@@ -100,60 +84,6 @@ enum class endian
 arr_real from_file(const std::string& file, dtype type = dtype::int16, endian order = endian::little, long offset = 0,
                    long count = std::numeric_limits<long>::max());
 
-//----------------------------------------------------------------------------------------------------------
-template<typename T>
-[[deprecated]] inline arr_real to_real(const T* x, size_t nx) {
-    return dsplib::arr_real(x, nx);
-}
-
-//----------------------------------------------------------------------------------------------------------
-template<typename T>
-[[deprecated]] inline arr_real to_real(const std::vector<T>& arr) {
-    return dsplib::arr_real(arr);
-}
-
-//----------------------------------------------------------------------------------------------------------
-template<typename T>
-[[deprecated]] inline std::vector<T> from_real(const arr_real& arr) {
-    static_assert(std::is_convertible<real_t, T>::value, "Type is not convertible");
-    static_assert(is_scalar_v<T>, "Type is not scalar");
-    std::vector<T> res(arr.size());
-    for (auto i = 0; i < arr.size(); i++) {
-        res[i] = arr[i];
-    }
-    return res;
-}
-
-template<typename T>
-[[deprecated]] inline arr_cmplx to_complex(const T* x, size_t nx) {
-    DSPLIB_ASSERT(nx % 2 == 0, "Array size is not even");
-    const T* p = x;
-    arr_cmplx r(nx / 2);
-    for (auto i = 0; i < r.size(); i++) {
-        r[i].re = *(p++);
-        r[i].im = *(p++);
-    }
-    return r;
-}
-
-template<typename T>
-[[deprecated]] inline arr_cmplx to_complex(const std::vector<T>& arr) {
-    static_assert(is_scalar_v<T>, "Type is not scalar");
-    return to_complex(arr.data(), arr.size());
-}
-
-template<typename T>
-[[deprecated]] inline std::vector<T> from_complex(const arr_cmplx& arr) {
-    static_assert(is_scalar_v<T>, "Type is not scalar");
-    static_assert(std::is_convertible<real_t, T>::value, "Type is not convertible");
-    std::vector<T> res(arr.size() * 2);
-    for (auto i = 0; i < arr.size(); i++) {
-        res[2 * i] = arr[i].re;
-        res[2 * i + 1] = arr[i].im;
-    }
-    return res;
-}
-
 //add zeros to the end of the array
 arr_real zeropad(span_t<real_t> x, int n);
 arr_cmplx zeropad(span_t<cmplx_t> x, int n);
@@ -161,7 +91,7 @@ arr_cmplx zeropad(span_t<cmplx_t> x, int n);
 //delays or advances the signal by the number of samples specified in delay
 //TODO: fractional delay support
 template<typename T>
-inline base_array<T> delayseq(const base_array<T>& data, int delay) {
+base_array<T> delayseq(const base_array<T>& data, int delay) {
     if (delay == 0) {
         return data;
     }

--- a/lib/czt.cpp
+++ b/lib/czt.cpp
@@ -49,10 +49,9 @@ public:
             xp[i] = x[i] * _cp[i];
         }
 
-        //TODO: inplace
-        xp = _fft2->solve(xp);
+        _fft2->solve(inplace(xp));
         xp *= _ich;
-        xp = _ifft2->solve(xp);
+        _ifft2->solve(inplace(xp));
 
         for (int i = 0; i < _n; ++i) {
             r[i] = xp[_n - 1 + i] * _rp[i];

--- a/lib/fft/fact-fft.cpp
+++ b/lib/fft/fact-fft.cpp
@@ -131,9 +131,7 @@ void _facfft(const PlanTree* plan, cmplx_t* restrict x, cmplx_t* restrict mem, c
     const int n = plan->size();
 
     if (!plan->has_next()) {
-        //TODO: inplace fft
-        plan->solver()->solve(make_span(x, n), make_span(mem, n));
-        std::memcpy(x, mem, n * sizeof(cmplx_t));
+        plan->solver()->solve(inplace(make_span(x, n)));
         return;
     }
 
@@ -188,11 +186,16 @@ FactorFFTPlan::FactorFFTPlan(int n)
 }
 
 void FactorFFTPlan::solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const {
-    DSPLIB_ASSERT(x.size() == _n, "input array size is not equal fft size");
     DSPLIB_ASSERT(x.size() == r.size(), "output array size error");
+    r.assign(x);
+    this->solve(inplace(r));
+}
+
+void FactorFFTPlan::solve(inplace_span_t<cmplx_t> r) const {
+    auto x = r.get();
+    DSPLIB_ASSERT(x.size() == _n, "input array size is not equal fft size");
     arr_cmplx tmp(_n);
-    r = x;   //TODO: remove copy
-    _facfft(_plan.get(), r.data(), tmp.data(), _twiddle.data(), _n);
+    _facfft(_plan.get(), x.data(), tmp.data(), _twiddle.data(), _n);
 }
 
 [[nodiscard]] int FactorFFTPlan::size() const noexcept {

--- a/lib/fft/fact-fft.h
+++ b/lib/fft/fact-fft.h
@@ -18,6 +18,7 @@ public:
 
     [[nodiscard]] arr_cmplx solve(span_t<cmplx_t> x) const final;
     void solve(span_t<cmplx_t> x, mut_span_t<cmplx_t> r) const final;
+    void solve(inplace_span_t<cmplx_t> r) const final;
     [[nodiscard]] int size() const noexcept final;
 
 private:

--- a/lib/fir.cpp
+++ b/lib/fir.cpp
@@ -11,14 +11,15 @@ namespace dsplib {
 namespace {
 
 template<class T>
-static void _conv(const T* restrict x, const T* restrict h, T* restrict r, int nh, int nx) {
+void _conv(T* restrict x, const T* restrict h, int nh, int nx) {
     const int nr = nx - nh + 1;
-    assert(nr > 0);
+    DSPLIB_ASSUME(nr > 0);
     for (int i = 0; i < nr; ++i) {
-        r[i] = 0;
+        T r = 0;
         for (int k = 0; k < nh; ++k) {
-            r[i] += x[i + k] * conj(h[nh - k - 1]);
+            r += x[i + k] * conj(h[nh - k - 1]);
         }
+        x[i] = r;
     }
 }
 
@@ -110,17 +111,12 @@ bool _is_antisymmetric(const dsplib::arr_real& h) {
 
 //-------------------------------------------------------------------------------------------------
 template<>
-arr_real FirFilter<real_t>::conv(const arr_real& x, const arr_real& h) {
-    arr_real r(x.size() - h.size() + 1);
-    _conv(x.data(), h.data(), r.data(), h.size(), x.size());
-    return r;
+void FirFilter<real_t>::conv(mut_span_t<real_t> x, span_t<real_t> h) {
+    _conv(x.data(), h.data(), h.size(), x.size());
 }
-
 template<>
-arr_cmplx FirFilter<cmplx_t>::conv(const arr_cmplx& x, const arr_cmplx& h) {
-    arr_cmplx r(x.size() - h.size() + 1);
-    _conv(x.data(), h.data(), r.data(), h.size(), x.size());
-    return r;
+void FirFilter<cmplx_t>::conv(mut_span_t<cmplx_t> x, span_t<cmplx_t> h) {
+    _conv(x.data(), h.data(), h.size(), x.size());
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/lib/gccphat.cpp
+++ b/lib/gccphat.cpp
@@ -5,7 +5,8 @@ namespace dsplib {
 gccphat_res_t gccphat(const arr_real& sig, const arr_real& refsig, int fs) {
     const real_t ts = 1.0 / fs;
     auto X1 = fft(sig);
-    auto X2 = conj(fft(refsig));
+    auto X2 = fft(refsig);
+    conj(inplace(X2));
     auto Y = X1 * X2;
     const auto R = ifft(Y / abs(Y));
     const auto n = argmax(R);
@@ -27,7 +28,8 @@ gccphat_res_t gccphat(const arr_real& sig, const arr_real& refsig, int fs) {
 
 gccphat_res_ch_t gccphat(const std::vector<arr_real>& sig, const arr_real& refsig, int fs) {
     const real_t ts = 1.0 / fs;
-    const auto X2 = conj(fft(refsig));
+    auto X2 = fft(refsig);
+    conj(inplace(X2));
     const int M = X2.size();
     const int M2 = M / 2;
     gccphat_res_ch_t res;

--- a/lib/math.cpp
+++ b/lib/math.cpp
@@ -61,19 +61,25 @@ int argmin(span_cmplx arr) {
 }
 
 //-------------------------------------------------------------------------------------------------
-arr_real abs(const arr_real& arr) {
-    arr_real r(arr);
-    for (int i = 0; i < r.size(); ++i) {
-        r[i] = std::fabs(r[i]);
+void abs(inplace_real arr) noexcept {
+    auto x = arr.get();
+    const int nx = x.size();
+    for (int i = 0; i < nx; ++i) {
+        x[i] = std::fabs(x[i]);
     }
+}
+
+arr_real abs(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    abs(inplace(r));
     return r;
 }
 
-real_t abs(real_t v) {
+real_t abs(real_t v) noexcept {
     return std::fabs(v);
 }
 
-arr_real abs(const arr_cmplx& arr) {
+arr_real abs(const arr_cmplx& arr) noexcept {
     arr_real r(arr.size());
     for (int i = 0; i < r.size(); ++i) {
         r[i] = std::sqrt(arr[i].re * arr[i].re + arr[i].im * arr[i].im);
@@ -81,34 +87,44 @@ arr_real abs(const arr_cmplx& arr) {
     return r;
 }
 
-real_t abs(cmplx_t v) {
+real_t abs(cmplx_t v) noexcept {
     return std::sqrt(v.re * v.re + v.im * v.im);
 }
 
 //-------------------------------------------------------------------------------------------------
-real_t round(const real_t& x) {
+real_t round(const real_t& x) noexcept {
     return std::round(x);
 }
 
-cmplx_t round(const cmplx_t& x) {
+cmplx_t round(const cmplx_t& x) noexcept {
     return cmplx_t{std::round(x.re), std::round(x.im)};
 }
 
 template<typename T>
-static base_array<T> _round(const base_array<T>& x) {
-    base_array<T> y(x.size());
+void _round(mut_span_t<T> x) noexcept {
     for (int i = 0; i < x.size(); ++i) {
-        y[i] = round(x[i]);
+        x[i] = round(x[i]);
     }
-    return y;
 }
 
-arr_real round(const arr_real& x) {
-    return _round(x);
+void round(inplace_real arr) noexcept {
+    _round(arr.get());
 }
 
-arr_cmplx round(const arr_cmplx& x) {
-    return _round(x);
+void round(inplace_cmplx arr) noexcept {
+    _round(arr.get());
+}
+
+arr_real round(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    round(inplace(r));
+    return r;
+}
+
+arr_cmplx round(const arr_cmplx& arr) noexcept {
+    arr_cmplx r(arr);
+    round(inplace(r));
+    return r;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -355,11 +371,16 @@ arr_real cos(const arr_real& arr) {
 }
 
 //-------------------------------------------------------------------------------------------------
-arr_cmplx conj(const arr_cmplx& x) {
-    arr_cmplx r(x);
+void conj(inplace_cmplx x) noexcept {
+    auto r = x.get();
     for (int i = 0; i < r.size(); ++i) {
         r[i].im = -r[i].im;
     }
+}
+
+arr_cmplx conj(const arr_cmplx& x) noexcept {
+    arr_cmplx r(x);
+    conj(inplace(r));
     return r;
 }
 
@@ -479,16 +500,21 @@ arr_cmplx power(const arr_cmplx& x, int n) {
 }
 
 //-------------------------------------------------------------------------------------------------
-real_t sqrt(real_t x) {
+real_t sqrt(real_t x) noexcept {
     return std::sqrt(x);
 }
 
-arr_real sqrt(const arr_real& x) {
-    arr_real y(x.size());
+void sqrt(inplace_real arr) noexcept {
+    auto x = arr.get();
     for (int i = 0; i < x.size(); ++i) {
-        y[i] = std::sqrt(x[i]);
+        x[i] = std::sqrt(x[i]);
     }
-    return y;
+}
+
+arr_real sqrt(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    sqrt(inplace(r));
+    return r;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -617,7 +643,7 @@ arr_cmplx upsample(const arr_cmplx& arr, int n, int phase) {
 }
 
 //-------------------------------------------------------------------------------------------------
-arr_real abs2(const arr_cmplx& x) {
+arr_real abs2(const arr_cmplx& x) noexcept {
     arr_real r(x.size());
     for (int i = 0; i < x.size(); i++) {
         r[i] = (x[i].re * x[i].re) + (x[i].im * x[i].im);
@@ -665,37 +691,73 @@ real_t rad2deg(const real_t& x) {
 }
 
 //-------------------------------------------------------------------------------------------------
-real_t pow2db(real_t v) {
+void pow2db(inplace_real arr) noexcept {
+    auto x = arr.get();
+    for (int i = 0; i < x.size(); ++i) {
+        x[i] = pow2db(x[i]);
+    }
+}
+
+void db2pow(inplace_real arr) noexcept {
+    auto x = arr.get();
+    for (int i = 0; i < x.size(); ++i) {
+        x[i] = db2pow(x[i]);
+    }
+}
+
+real_t pow2db(real_t v) noexcept {
     return 10 * std::log10(v);
 }
 
-arr_real pow2db(const arr_real& v) {
-    return 10 * log10(v);
+arr_real pow2db(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    pow2db(inplace(r));
+    return r;
 }
 
-real_t db2pow(real_t v) {
+real_t db2pow(real_t v) noexcept {
     return std::pow(real_t(10), (v / 10));
 }
 
-arr_real db2pow(const arr_real& v) {
-    return power(10, (v / 10));
+arr_real db2pow(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    db2pow(inplace(r));
+    return r;
 }
 
 //-------------------------------------------------------------------------------------------------
-real_t mag2db(real_t v) {
+void mag2db(inplace_real arr) noexcept {
+    auto x = arr.get();
+    for (int i = 0; i < x.size(); ++i) {
+        x[i] = mag2db(x[i]);
+    }
+}
+
+void db2mag(inplace_real arr) noexcept {
+    auto x = arr.get();
+    for (int i = 0; i < x.size(); ++i) {
+        x[i] = db2mag(x[i]);
+    }
+}
+
+real_t mag2db(real_t v) noexcept {
     return 20 * std::log10(v);
 }
 
-arr_real mag2db(const arr_real& v) {
-    return 20 * log10(v);
+arr_real mag2db(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    mag2db(inplace(r));
+    return r;
 }
 
-real_t db2mag(real_t v) {
+real_t db2mag(real_t v) noexcept {
     return std::pow(real_t(10), (v / 20));
 }
 
-arr_real db2mag(const arr_real& v) {
-    return power(10, (v / 20));
+arr_real db2mag(const arr_real& arr) noexcept {
+    arr_real r(arr);
+    db2mag(inplace(r));
+    return r;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/lib/resample/resample.cpp
+++ b/lib/resample/resample.cpp
@@ -72,7 +72,7 @@ std::vector<arr_real> IResampler::polyphase(arr_real h, int m, real_t gain, bool
 
     if (flip_coeffs) {
         for (int i = 0; i < m; ++i) {
-            r[i] = flip(r[i]);
+            flip(inplace(r[i]));
         }
     }
 

--- a/lib/subband.cpp
+++ b/lib/subband.cpp
@@ -189,8 +189,10 @@ public:
             }
         }
 
-        //TODO: remove conj
-        return conj(fft_->solve(pout));
+        //TODO: flip and remove conj
+        auto out = fft_->solve(pout);
+        conj(inplace(out));
+        return out;
     }
 
 private:

--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -157,7 +157,7 @@ arr_real kaiser(int nw, real_t beta) {
         const auto xi = 4 * abs2(i + 0.5 * (1 - odd));
         w[i] = besseli0(beta * std::sqrt(1 - (xi / xind))) / bes;
     }
-    const arr_real wl = flip(*w.slice(odd, n));
+    const arr_real wl = flip(w.slice(odd, n));
     return concatenate(wl, w);
 }
 

--- a/lib/xcorr.cpp
+++ b/lib/xcorr.cpp
@@ -4,41 +4,46 @@
 #include <dsplib/math.h>
 #include <dsplib/utils.h>
 
-#include <algorithm>
-
 namespace dsplib {
 
-//-------------------------------------------------------------------------------------------------
-arr_cmplx xcorr(const arr_cmplx& x1, const arr_cmplx& x2) {
+namespace {
+
+template<typename T>
+arr_cmplx _xcorr(const base_array<T>& x1, const base_array<T>& x2) {
     const int N1 = x1.size();
     const int N2 = x2.size();
     const int M = 1L << nextpow2(N1 + N2 - 1);
 
-    arr_cmplx y1 = x1 | zeros(M - x1.size());
-    arr_cmplx y2 = zeros(M - x2.size()) | x2;
+    auto y1 = x1 | zeros(M - x1.size());
+    auto y2 = zeros(M - x2.size()) | x2;
 
-    arr_cmplx z1 = conj(fft(y1));
-    arr_cmplx z2 = fft(y2);
-    arr_cmplx z = conj(ifft(z1 * z2));
+    auto z1 = fft(y1);
+    conj(inplace(z1));
+    auto z2 = fft(y2);
+    z1 *= z2;
+    auto z = ifft(z1);
+    conj(inplace(z));
 
     z = flip(z.slice(M - N1 - N2 + 1, M));
     return z;
 }
 
-//-------------------------------------------------------------------------------------------------
+}   // namespace
+
+arr_cmplx xcorr(const arr_cmplx& x1, const arr_cmplx& x2) {
+    return _xcorr(x1, x2);
+}
+
 arr_real xcorr(const arr_real& x1, const arr_real& x2) {
-    //TODO: real fft optimization
-    return real(xcorr(complex(x1), complex(x2)));
+    return real(_xcorr(x1, x2));
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_real xcorr(const arr_real& x) {
-    return real(xcorr(complex(x), complex(x)));
+    return real(_xcorr(x, x));
 }
 
-//-------------------------------------------------------------------------------------------------
 arr_cmplx xcorr(const arr_cmplx& x) {
-    return xcorr(x, x);
+    return _xcorr(x, x);
 }
 
 }   // namespace dsplib

--- a/tests/fir_test.cpp
+++ b/tests/fir_test.cpp
@@ -323,7 +323,7 @@ TEST(FirTest, MAFilterStress) {
     int num_tests = 1000;
     while (--num_tests != 0) {
         auto x = randn(10000);
-        const int w = randi({1, 500});
+        const int w = randi({2, 500});
         auto h = ones(w) / w;
         FirFilterR fir_flt(h);
         const auto y1 = fir_flt.process(x);

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -541,3 +541,18 @@ TEST(MathTest, Sqrt) {
     arr_real y = dsplib::sqrt(abs2(x));
     ASSERT_EQ_ARR_REAL(y, x);
 }
+
+//-------------------------------------------------------------------------------------------------
+TEST(MathTest, Round) {
+    {
+        arr_real x = {1.1, 2.2, 3.5, 4.6};
+        arr_real r = {1, 2, 4, 5};
+        ASSERT_EQ_ARR_REAL(round(x), r);
+    }
+
+    {
+        arr_cmplx x = {1 + 1.1i, 2.2 + 3.5i, 4 - 1.1i, 4.4999 - 4.6i};
+        arr_cmplx r = {1 + 1i, 2 + 4i, 4 - 1i, 4 - 5i};
+        ASSERT_EQ_ARR_CMPLX(round(x), r);
+    }
+}

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -317,7 +317,7 @@ TEST(Utils, ZadoffChu) {
         auto y = zadoff_chu(n - 1, n);
         ASSERT_EQ_ARR_CMPLX(x, conj(y));
         //must be symmetry
-        ASSERT_EQ_ARR_CMPLX(*x.slice(0, n / 2), flip(*x.slice(n / 2 + 1, n)));
-        ASSERT_EQ_ARR_CMPLX(*y.slice(0, n / 2), flip(*y.slice(n / 2 + 1, n)));
+        ASSERT_EQ_ARR_CMPLX(x.slice(0, n / 2), flip(x.slice(n / 2 + 1, n)));
+        ASSERT_EQ_ARR_CMPLX(y.slice(0, n / 2), flip(y.slice(n / 2 + 1, n)));
     }
 }


### PR DESCRIPTION
Use `inplace' to explicitly specify calculations on the input data.

- Add `inplace_span_t<T>` class;
- Add `inplace` function;
- Add some inplace functions;
- Add inplace version of `solve` for `FftPlanC`;
- Code refactoring;