### PR TITLE
Fix complex FIR coefficient convention to match MATLAB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(dsplib LANGUAGES CXX VERSION 1.3.0)
+project(dsplib LANGUAGES CXX VERSION 1.5.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ required_conan_version = ">=2.1.0"
 
 class DsplibConan(ConanFile):
     name = "dsplib"
-    version = "1.3.0"
+    version = "1.5.0"
     license = "MIT"
     package_type = "library"
     author = "Vitaly Yulis (vitaly.yulis@gmail.com)"

--- a/include/dsplib/fir.h
+++ b/include/dsplib/fir.h
@@ -10,7 +10,8 @@ namespace dsplib {
 
 /*!
  * \brief FIR filter class
- * \todo complex type support
+ * \warning Coefficients are the impulse response h[0], h[1], ...: y[n] = sum(h[k] * x[n-k]).
+ * No complex conjugation is applied (MATLAB filter(h, 1, x) convention).
  */
 template<typename T>
 class FirFilter
@@ -69,6 +70,8 @@ class FftFilterImpl;
 /*!
  * \brief FFT-based FIR filtering using overlap-add method
  * \details Fast fir implementation for large IR length (usually > 200)
+ * \warning Coefficients are the impulse response h[0], h[1], ...: y[n] = sum(h[k] * x[n-k]).
+ * No complex conjugation is applied (MATLAB filter(h, 1, x) convention).
  */
 template<typename T>
 class FftFilter

--- a/include/dsplib/math.h
+++ b/include/dsplib/math.h
@@ -84,7 +84,7 @@ arr_real cumsum(span_real x, Direction dir = Direction::Forward);
 arr_cmplx cumsum(span_cmplx x, Direction dir = Direction::Forward);
 
 //dot product of two arrays
-//warn: without using the complex conjugate
+//warn: without using the complex conjugate (non-matlab style)
 //sum(x1 * x2)
 real_t dot(span_real x1, span_real x2);
 cmplx_t dot(span_cmplx x1, span_cmplx x2);

--- a/lib/detector.cpp
+++ b/lib/detector.cpp
@@ -95,7 +95,7 @@ public:
 
 private:
     static arr_cmplx _convert_impulse(span_cmplx h) {
-        return flip(h) / (rms(h) * h.size());
+        return conj(flip(h)) / (rms(h) * h.size());
     }
 
     FftFilterC _corr_flt;

--- a/lib/fft-filter.cpp
+++ b/lib/fft-filter.cpp
@@ -13,7 +13,7 @@ public:
       , _x(_nfft)
       , _olap(_m - 1) {
         assert(_n > _m);
-        _h = fft(conj(h), _nfft);
+        _h = fft(h, _nfft);
     }
 
     base_array<T> process(span_t<T> x) {

--- a/lib/fir.cpp
+++ b/lib/fir.cpp
@@ -17,7 +17,7 @@ void _conv(T* restrict x, const T* restrict h, int nh, int nx) {
     for (int i = 0; i < nr; ++i) {
         T r = 0;
         for (int k = 0; k < nh; ++k) {
-            r += x[i + k] * conj(h[nh - k - 1]);
+            r += x[i + k] * h[nh - k - 1];
         }
         x[i] = r;
     }

--- a/tests/fir_test.cpp
+++ b/tests/fir_test.cpp
@@ -26,6 +26,20 @@ TEST(FirTest, FftFirAndOne) {
 }
 
 //-------------------------------------------------------------------------------------------------
+TEST(FirTest, CmplxImpulseResponse) {
+    const arr_cmplx h = {1.0 + 2.0i, -0.5 + 0.25i, 0.75 - 1.5i};
+    auto fir = FirFilterC(h);
+    auto fft_fir = FftFilterC(h);
+    auto x = complex(zeros(fft_fir.block_size()));
+    x[0] = 1;
+    arr_cmplx expected(x.size());
+    expected.slice(0, h.size()) = h;
+
+    ASSERT_EQ_ARR_CMPLX(fir(x), expected);
+    ASSERT_EQ_ARR_CMPLX(fft_fir(x), expected);
+}
+
+//-------------------------------------------------------------------------------------------------
 TEST(FirTest, FftEqFir) {
     for (int nh = 1; nh <= 128; ++nh) {
         const auto ir_coeff = fir1(nh, 0.1);
@@ -114,34 +128,44 @@ TEST(FirTest, Rls) {
 
 //-------------------------------------------------------------------------------------------------
 TEST(FirTest, LmsCmplx) {
+    const real_t noise_std = 0.01;
+    const real_t mu = 0.5;
     auto h = _get_bandpass_fir(32, 0.1, 0.2);
     int M = h.size();
     int L = 10000;
     auto flt = FirFilterC(h);
     arr_cmplx x = complex(randn(L), randn(L));
-    arr_cmplx n = 0.01 * complex(randn(L), randn(L));
+    arr_cmplx n = noise_std * complex(randn(L), randn(L));
     arr_cmplx d = flt(x) + n;
 
-    auto adapt = LmsFilterC(M, 0.5, LmsType::NLMS);
+    auto adapt = LmsFilterC(M, mu, LmsType::NLMS);
     auto [y, e] = adapt(x, d);
     auto w = adapt.coeffs();
-    ASSERT_LE(nmse(w, h), 0.1);
+    // Approximate coefficient MSE: (noise power / input power) * mu / ((2-mu) * M).
+    // Allow for finite-sample effects and random noise fluctuations.
+    const real_t max_mse = 10 * noise_std * noise_std * mu / ((2 - mu) * M);
+    ASSERT_LE(mse(w, h), max_mse);
 }
 
 //-------------------------------------------------------------------------------------------------
 TEST(FirTest, RlsCmplx) {
+    const real_t noise_std = 0.01;
+    const real_t mu = 0.98;
     auto h = _get_bandpass_fir(32, 0.1, 0.2);
     int M = h.size();
     int L = 10000;
     auto flt = FirFilterC(h);
     arr_cmplx x = complex(randn(L), randn(L));
-    arr_cmplx n = 0.01 * complex(randn(L), randn(L));
+    arr_cmplx n = noise_std * complex(randn(L), randn(L));
     arr_cmplx d = flt(x) + n;
 
-    auto adapt = RlsFilterC(M, 0.98);
+    auto adapt = RlsFilterC(M, mu);
     auto [y, e] = adapt(x, d);
     auto w = adapt.coeffs();
-    ASSERT_LE(nmse(w, h), 0.1);
+    // Approximate coefficient MSE: (noise power / input power) * (1-mu)/(1+mu).
+    // Allow for finite-sample covariance and random noise fluctuations.
+    const real_t max_mse = 10 * noise_std * noise_std * (1 - mu) / (1 + mu);
+    ASSERT_LE(mse(w, h), max_mse);
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Remove implicit conjugation from FIR and FFT filters
- Conjugate matched-filter coefficients explicitly in preamble detector
- Tighten complex LMS/RLS tests and verify impulse response
- Document coefficient convention